### PR TITLE
Replaced 'new Matrix()' with 'math.matrix()' call

### DIFF
--- a/lib/expression/transform/map.transform.js
+++ b/lib/expression/transform/map.transform.js
@@ -23,7 +23,7 @@ module.exports = function (math) {
     if (Array.isArray(x)) {
       return _mapArray(x, callback, x);
     } else if (x instanceof Matrix) {
-      return new Matrix(_mapArray(x.valueOf(), callback, x))
+      return math.matrix(_mapArray(x.valueOf(), callback, x));
     } else {
       throw new math.error.UnsupportedTypeError('map', math['typeof'](x));
     }

--- a/lib/function/matrix/concat.js
+++ b/lib/function/matrix/concat.js
@@ -102,7 +102,7 @@ module.exports = function (math) {
       res = _concat(res, matrices.shift(), dim, 0);
     }
 
-    return asMatrix ? new Matrix(res) : res;
+    return asMatrix ? math.matrix(res) : res;
   };
 
   /**

--- a/lib/function/matrix/cross.js
+++ b/lib/function/matrix/cross.js
@@ -36,15 +36,15 @@ module.exports = function(math) {
   math.cross = function cross(x, y) {
     if (x instanceof Matrix) {
       if (y instanceof Matrix) {
-        return new Matrix(_cross(x.toArray(), y.toArray()));
+        return math.matrix(_cross(x.toArray(), y.toArray()));
       }
       else if (Array.isArray(y)) {
-        return new Matrix(_cross(x.toArray(), y));
+        return math.matrix(_cross(x.toArray(), y));
       }
     }
     else if (Array.isArray(x)) {
       if (y instanceof Matrix) {
-        return new Matrix(_cross(x, y.toArray()));
+        return math.matrix(_cross(x, y.toArray()));
       }
       else if (Array.isArray(y)) {
         return _cross(x, y);

--- a/lib/function/matrix/flatten.js
+++ b/lib/function/matrix/flatten.js
@@ -35,7 +35,7 @@ module.exports = function (math, config) {
     if (x instanceof Matrix) {
       var clone = object.clone(x.toArray());
       var flat = array.flatten(clone);
-      return new Matrix(flat);
+      return math.matrix(flat);
     }
 
     if (isArray(x)) {

--- a/lib/function/matrix/ones.js
+++ b/lib/function/matrix/ones.js
@@ -42,9 +42,9 @@ module.exports = function (math, config) {
     var asMatrix = (size instanceof Matrix) ? true :
         (isArray(size) ? false : (config.matrix === 'matrix'));
 
-    if (args.length == 0) {
+    if (args.length === 0) {
       // output an empty matrix
-      return asMatrix ? new Matrix() : [];
+      return asMatrix ? math.matrix() : [];
     }
     else {
       // output an array or matrix
@@ -65,7 +65,7 @@ module.exports = function (math, config) {
       var defaultValue = asBigNumber ? new BigNumber(1) : 1;
       res = array.resize(res, args, defaultValue);
 
-      return asMatrix ? new Matrix(res) : res;
+      return asMatrix ? math.matrix(res) : res;
     }
   };
 };

--- a/lib/function/matrix/range.js
+++ b/lib/function/matrix/range.js
@@ -4,7 +4,6 @@ module.exports = function (math, config) {
   var util = require('../../util/index'),
 
       BigNumber = math.type.BigNumber,
-      Matrix = require('../../type/Matrix'),
       collection = require('../../type/collection'),
 
       isBoolean = util['boolean'].isBoolean,
@@ -145,7 +144,7 @@ module.exports = function (math, config) {
     var array = fn(start, end, step);
 
     // return as array or matrix
-    return (config.matrix === 'array') ? array : new Matrix(array);
+    return (config.matrix === 'array') ? array : math.matrix(array);
   };
 
   /**

--- a/lib/function/matrix/resize.js
+++ b/lib/function/matrix/resize.js
@@ -65,7 +65,7 @@ module.exports = function (math, config) {
       return _resizeString(x, size, defaultValue);
     }
     else {
-      if (size.length == 0) {
+      if (size.length === 0) {
         // output a scalar
         while (isArray(x)) {
           x = x[0];
@@ -81,7 +81,7 @@ module.exports = function (math, config) {
         x = clone(x);
 
         var res = array.resize(x, size, defaultValue);
-        return asMatrix ? new Matrix(res) : res;
+        return asMatrix ? math.matrix(res) : res;
       }
     }
   };

--- a/lib/function/matrix/size.js
+++ b/lib/function/matrix/size.js
@@ -47,11 +47,11 @@ module.exports = function (math, config) {
 
     if (isNumber(x) || isComplex(x) || isUnit(x) || isBoolean(x) ||
         x == null || x instanceof BigNumber) {
-      return asArray ? [] : new Matrix([]);
+      return asArray ? [] : math.matrix([]);
     }
 
     if (isString(x)) {
-      return asArray ? [x.length] : new Matrix([x.length]);
+      return asArray ? [x.length] : math.matrix([x.length]);
     }
 
     if (Array.isArray(x)) {
@@ -59,7 +59,7 @@ module.exports = function (math, config) {
     }
 
     if (x instanceof Matrix) {
-      return new Matrix(x.size());
+      return math.matrix(x.size());
     }
 
     throw new math.error.UnsupportedTypeError('size', math['typeof'](x));

--- a/lib/function/matrix/squeeze.js
+++ b/lib/function/matrix/squeeze.js
@@ -48,7 +48,7 @@ module.exports = function (math) {
     }
     else if (x instanceof Matrix) {
       var res = array.squeeze(x.toArray());
-      return isArray(res) ? new Matrix(res) : res;
+      return isArray(res) ? math.matrix(res) : res;
     }
     else {
       // scalar

--- a/lib/function/matrix/subset.js
+++ b/lib/function/matrix/subset.js
@@ -71,7 +71,7 @@ module.exports = function (math) {
     var m, subset;
 
     if (isArray(value)) {
-      m = new Matrix(value);
+      m = math.matrix(value);
       subset = m.subset(index);           // returns a Matrix
       return subset && subset.valueOf();  // return an Array (like the input)
     }
@@ -133,7 +133,7 @@ module.exports = function (math) {
     var m;
 
     if (isArray(value)) {
-      m = new Matrix(math.clone(value));
+      m = math.matrix(math.clone(value));
       m.subset(index, replacement, defaultValue);
       return m.valueOf();
     }

--- a/lib/function/matrix/trace.js
+++ b/lib/function/matrix/trace.js
@@ -44,7 +44,7 @@ module.exports = function (math) {
       size = x.size();
     }
     else if (x instanceof Array) {
-      x = new Matrix(x);
+      x = math.matrix(x);
       size = x.size();
     }
     else {

--- a/lib/function/matrix/zeros.js
+++ b/lib/function/matrix/zeros.js
@@ -41,9 +41,9 @@ module.exports = function (math, config) {
     var asMatrix = (size instanceof Matrix) ? true :
         (isArray(size) ? false : (config.matrix === 'matrix'));
 
-    if (args.length == 0) {
+    if (args.length === 0) {
       // output an empty matrix
-      return asMatrix ? new Matrix() : [];
+      return asMatrix ? math.matrix() : [];
     }
     else {
       // output an array or matrix
@@ -64,7 +64,7 @@ module.exports = function (math, config) {
       var defaultValue = asBigNumber ? new BigNumber(0) : 0;
       res = array.resize(res, args, defaultValue);
 
-      return asMatrix ? new Matrix(res) : res;
+      return asMatrix ? math.matrix(res) : res;
     }
   };
 };

--- a/lib/function/probability/distribution.js
+++ b/lib/function/probability/distribution.js
@@ -80,7 +80,7 @@ module.exports = function (math) {
           if (min === undefined) min = 0;
           if (size !== undefined) {
             var res = _randomDataForMatrix(size.valueOf(), min, max, _random);
-            return (size instanceof Matrix) ? new Matrix(res) : res;
+            return (size instanceof Matrix) ? math.matrix(res) : res;
           }
           else return _random(min, max);
         },
@@ -120,7 +120,7 @@ module.exports = function (math) {
           if (min === undefined) min = 0;
           if (size !== undefined) {
             var res = _randomDataForMatrix(size.valueOf(), min, max, _randomInt);
-            return (size instanceof Matrix) ? new Matrix(res) : res;
+            return (size instanceof Matrix) ? math.matrix(res) : res;
           }
           else return _randomInt(min, max);
         },
@@ -173,7 +173,7 @@ module.exports = function (math) {
       return randFunctions;
 
     })(distribution);
-  };
+  }
 
   // Each distribution is a function that takes no argument and when called returns
   // a number between 0 and 1.
@@ -199,7 +199,7 @@ module.exports = function (math) {
           picked = 1/6 * Math.pow(-2 * Math.log(u1), 0.5) * Math.cos(2 * Math.PI * u2) + 0.5;
         }
         return picked;
-      }
+      };
     }
   };
 

--- a/lib/type/Matrix.js
+++ b/lib/type/Matrix.js
@@ -18,7 +18,7 @@ var validateIndex = array.validateIndex;
  *
  * A Matrix is a wrapper around an Array. A matrix can hold a multi dimensional
  * array. A matrix can be constructed as:
- *     var matrix = new Matrix(data)
+ *     var matrix = math.matrix(data)
  *
  * Matrix contains the functions to resize, get and set values, get the size,
  * clone the matrix and to convert the matrix to a vector, array, or scalar.
@@ -26,7 +26,7 @@ var validateIndex = array.validateIndex;
  * The internal Array of the Matrix can be accessed using the function valueOf.
  *
  * Example usage:
- *     var matrix = new Matrix([[1, 2], [3, 4]);
+ *     var matrix = math.matrix([[1, 2], [3, 4]);
  *     matix.size();              // [2, 2]
  *     matrix.resize([3, 2], 5);
  *     matrix.valueOf();          // [[1, 2], [3, 4], [5, 5]]
@@ -499,7 +499,7 @@ Matrix.prototype.toJSON = function () {
   return {
     mathjs: 'Matrix',
     data: this._data
-  }
+  };
 };
 
 /**

--- a/lib/type/collection.js
+++ b/lib/type/collection.js
@@ -9,8 +9,7 @@ var util = require('../util/index'),
     Matrix = require('./Matrix'),
 
     array = util.array,
-    isArray = util.array.isArray,
-    isString = util.string.isString;
+    isArray = util.array.isArray;
 
 /**
  * Convert function arguments to an array. Arguments can have the following
@@ -23,7 +22,7 @@ var util = require('../util/index'),
  * @returns {Array} array
  */
 exports.argsToArray = function(args) {
-  if (args.length == 0) {
+  if (args.length === 0) {
     // fn()
     return [];
   }
@@ -204,7 +203,7 @@ function _reduce(mat, dim, callback){
 			for(i=0; i<tran.length; i++){
 				ret[i] = _reduce(tran[i], dim-1, callback);
 			}
-			return ret
+			return ret;
 		}
 	}else{
 		ret = [];

--- a/test/expression/parse.test.js
+++ b/test/expression/parse.test.js
@@ -43,9 +43,9 @@ describe('parse', function() {
 
   it('should parse a matrix with expressions', function() {
     var scope = {};
-    assert.deepEqual(parse(new Matrix(['a=3', 'b=4', 'a*b'])).map(function (node) {
+    assert.deepEqual(parse(math.matrix(['a=3', 'b=4', 'a*b'])).map(function (node) {
       return node.compile(math).eval(scope);
-    }), new Matrix([3, 4, 12]));
+    }), math.matrix([3, 4, 12]));
   });
 
   it('should parse an array with an empty expression', function() {
@@ -55,9 +55,9 @@ describe('parse', function() {
   });
 
   it('should parse an array with an empty expression', function() {
-    assert.deepEqual(parse(new Matrix([''])).map(function (node) {
+    assert.deepEqual(parse(math.matrix([''])).map(function (node) {
       return node.compile(math).eval();
-    }), new Matrix([undefined]));
+    }), math.matrix([undefined]));
   });
 
   describe('multiline', function () {
@@ -97,12 +97,12 @@ describe('parse', function() {
     });
 
     it('should spread a matrix over multiple lines', function() {
-      assert.deepEqual(parse('[\n1\n,\n2\n]').compile(math).eval(), new Matrix([1, 2]));
+      assert.deepEqual(parse('[\n1\n,\n2\n]').compile(math).eval(), math.matrix([1, 2]));
     });
 
     it('should spread a range over multiple lines', function() {
-      assert.deepEqual(parse('2:\n4').compile(math).eval(), new Matrix([2,3,4]));
-      assert.deepEqual(parse('2:\n2:\n6').compile(math).eval(), new Matrix([2,4,6]));
+      assert.deepEqual(parse('2:\n4').compile(math).eval(), math.matrix([2,3,4]));
+      assert.deepEqual(parse('2:\n2:\n6').compile(math).eval(), math.matrix([2,4,6]));
     });
 
     it('should spread an index over multiple lines', function() {
@@ -308,63 +308,63 @@ describe('parse', function() {
 
       var m = parseAndEval('[1,2,3;4,5,6]');
       assert.deepEqual(m.size(), [2,3]);
-      assert.deepEqual(m, new Matrix([[1,2,3],[4,5,6]]));
+      assert.deepEqual(m, math.matrix([[1,2,3],[4,5,6]]));
 
       var b = parseAndEval('[5, 6; 1, 1]');
       assert.deepEqual(b.size(), [2,2]);
-      assert.deepEqual(b, new Matrix([[5,6],[1,1]]));
+      assert.deepEqual(b, math.matrix([[5,6],[1,1]]));
 
       // from 1 to n dimensions
-      assert.deepEqual(parseAndEval('[ ]'), new Matrix([]));
-      assert.deepEqual(parseAndEval('[1,2,3]'), new Matrix([1,2,3]));
-      assert.deepEqual(parseAndEval('[1;2;3]'), new Matrix([[1],[2],[3]]));
-      assert.deepEqual(parseAndEval('[[1,2],[3,4]]'), new Matrix([[1,2],[3,4]]));
-      assert.deepEqual(parseAndEval('[[[1],[2]],[[3],[4]]]'), new Matrix([[[1],[2]],[[3],[4]]]));
+      assert.deepEqual(parseAndEval('[ ]'), math.matrix([]));
+      assert.deepEqual(parseAndEval('[1,2,3]'), math.matrix([1,2,3]));
+      assert.deepEqual(parseAndEval('[1;2;3]'), math.matrix([[1],[2],[3]]));
+      assert.deepEqual(parseAndEval('[[1,2],[3,4]]'), math.matrix([[1,2],[3,4]]));
+      assert.deepEqual(parseAndEval('[[[1],[2]],[[3],[4]]]'), math.matrix([[[1],[2]],[[3],[4]]]));
     });
 
     it('should parse an empty matrix', function() {
-      assert.deepEqual(parseAndEval('[]'), new Matrix([]));
+      assert.deepEqual(parseAndEval('[]'), math.matrix([]));
     });
 
     it('should get a matrix subset', function() {
       var scope = {
-        a: new Matrix([
+        a: math.matrix([
           [1,2,3],
           [4,5,6],
           [7,8,9]
         ])
       };
-      assert.deepEqual(parseAndEval('a[2, :]', scope),        new Matrix([[4,5,6]]));
-      assert.deepEqual(parseAndEval('a[2, :2]', scope),       new Matrix([[4,5]]));
-      assert.deepEqual(parseAndEval('a[2, :end-1]', scope),   new Matrix([[4,5]]));
-      assert.deepEqual(parseAndEval('a[2, 2:]', scope),       new Matrix([[5,6]]));
-      assert.deepEqual(parseAndEval('a[2, 2:3]', scope),      new Matrix([[5,6]]));
-      assert.deepEqual(parseAndEval('a[2, 1:2:3]', scope),    new Matrix([[4,6]]));
-      assert.deepEqual(parseAndEval('a[:, 2]', scope),        new Matrix([[2],[5],[8]]));
-      assert.deepEqual(parseAndEval('a[:2, 2]', scope),       new Matrix([[2],[5]]));
-      assert.deepEqual(parseAndEval('a[:end-1, 2]', scope),   new Matrix([[2],[5]]));
-      assert.deepEqual(parseAndEval('a[2:, 2]', scope),       new Matrix([[5],[8]]));
-      assert.deepEqual(parseAndEval('a[2:3, 2]', scope),      new Matrix([[5],[8]]));
-      assert.deepEqual(parseAndEval('a[1:2:3, 2]', scope),    new Matrix([[2],[8]]));
+      assert.deepEqual(parseAndEval('a[2, :]', scope),        math.matrix([[4,5,6]]));
+      assert.deepEqual(parseAndEval('a[2, :2]', scope),       math.matrix([[4,5]]));
+      assert.deepEqual(parseAndEval('a[2, :end-1]', scope),   math.matrix([[4,5]]));
+      assert.deepEqual(parseAndEval('a[2, 2:]', scope),       math.matrix([[5,6]]));
+      assert.deepEqual(parseAndEval('a[2, 2:3]', scope),      math.matrix([[5,6]]));
+      assert.deepEqual(parseAndEval('a[2, 1:2:3]', scope),    math.matrix([[4,6]]));
+      assert.deepEqual(parseAndEval('a[:, 2]', scope),        math.matrix([[2],[5],[8]]));
+      assert.deepEqual(parseAndEval('a[:2, 2]', scope),       math.matrix([[2],[5]]));
+      assert.deepEqual(parseAndEval('a[:end-1, 2]', scope),   math.matrix([[2],[5]]));
+      assert.deepEqual(parseAndEval('a[2:, 2]', scope),       math.matrix([[5],[8]]));
+      assert.deepEqual(parseAndEval('a[2:3, 2]', scope),      math.matrix([[5],[8]]));
+      assert.deepEqual(parseAndEval('a[1:2:3, 2]', scope),    math.matrix([[2],[8]]));
     });
 
     it('should parse matrix resizings', function() {
       var scope = {};
-      assert.deepEqual(parseAndEval('a = []', scope),    new Matrix([]));
-      assert.deepEqual(parseAndEval('a[1:3,1] = [1;2;3]', scope), new Matrix([[1],[2],[3]]));
-      assert.deepEqual(parseAndEval('a[:,2] = [4;5;6]', scope), new Matrix([[1,4],[2,5],[3,6]]));
+      assert.deepEqual(parseAndEval('a = []', scope),    math.matrix([]));
+      assert.deepEqual(parseAndEval('a[1:3,1] = [1;2;3]', scope), math.matrix([[1],[2],[3]]));
+      assert.deepEqual(parseAndEval('a[:,2] = [4;5;6]', scope), math.matrix([[1,4],[2,5],[3,6]]));
 
-      assert.deepEqual(parseAndEval('a = []', scope),    new Matrix([]));
-      assert.deepEqual(parseAndEval('a[1,3] = 3', scope), new Matrix([[0,0,3]]));
-      assert.deepEqual(parseAndEval('a[2,:] = [[4,5,6]]', scope), new Matrix([[0,0,3],[4,5,6]]));
+      assert.deepEqual(parseAndEval('a = []', scope),    math.matrix([]));
+      assert.deepEqual(parseAndEval('a[1,3] = 3', scope), math.matrix([[0,0,3]]));
+      assert.deepEqual(parseAndEval('a[2,:] = [[4,5,6]]', scope), math.matrix([[0,0,3],[4,5,6]]));
 
-      assert.deepEqual(parseAndEval('a = []', scope),    new Matrix([]));
-      assert.deepEqual(parseAndEval('a[3,1] = 3', scope), new Matrix([[0],[0],[3]]));
-      assert.deepEqual(parseAndEval('a[:,2] = [4;5;6]', scope), new Matrix([[0,4],[0,5],[3,6]]));
+      assert.deepEqual(parseAndEval('a = []', scope),    math.matrix([]));
+      assert.deepEqual(parseAndEval('a[3,1] = 3', scope), math.matrix([[0],[0],[3]]));
+      assert.deepEqual(parseAndEval('a[:,2] = [4;5;6]', scope), math.matrix([[0,4],[0,5],[3,6]]));
 
-      assert.deepEqual(parseAndEval('a = []', scope),    new Matrix([]));
-      assert.deepEqual(parseAndEval('a[1,1:3] = [[1,2,3]]', scope), new Matrix([[1,2,3]]));
-      assert.deepEqual(parseAndEval('a[2,:] = [[4,5,6]]', scope), new Matrix([[1,2,3],[4,5,6]]));
+      assert.deepEqual(parseAndEval('a = []', scope),    math.matrix([]));
+      assert.deepEqual(parseAndEval('a[1,1:3] = [[1,2,3]]', scope), math.matrix([[1,2,3]]));
+      assert.deepEqual(parseAndEval('a[2,:] = [[4,5,6]]', scope), math.matrix([[1,2,3],[4,5,6]]));
     });
 
     it('should get/set the matrix correctly', function() {
@@ -372,14 +372,14 @@ describe('parse', function() {
       parseAndEval('a=[1,2;3,4]', scope);
       parseAndEval('a[1,1] = 100', scope);
       assert.deepEqual(scope.a.size(), [2,2]);
-      assert.deepEqual(scope.a, new Matrix([[100,2],[3,4]]));
+      assert.deepEqual(scope.a, math.matrix([[100,2],[3,4]]));
       parseAndEval('a[2:3,2:3] = [10,11;12,13]', scope);
       assert.deepEqual(scope.a.size(), [3,3]);
-      assert.deepEqual(scope.a, new Matrix([[100, 2, 0],[3,10,11],[0,12,13]]));
+      assert.deepEqual(scope.a, math.matrix([[100, 2, 0],[3,10,11],[0,12,13]]));
       var a = scope.a;
       // note: after getting subset, uninitialized elements are replaced by elements with an undefined value
-      assert.deepEqual(a.subset(math.index([0,3], [0,2])), new Matrix([[100,2],[3,10],[0,12]]));
-      assert.deepEqual(parseAndEval('a[1:3,1:2]', scope), new Matrix([[100,2],[3,10],[0,12]]));
+      assert.deepEqual(a.subset(math.index([0,3], [0,2])), math.matrix([[100,2],[3,10],[0,12]]));
+      assert.deepEqual(parseAndEval('a[1:3,1:2]', scope), math.matrix([[100,2],[3,10],[0,12]]));
 
       scope.b = [[1,2],[3,4]];
       assert.deepEqual(parseAndEval('b[1,:]', scope), [[1, 2]]);
@@ -387,10 +387,10 @@ describe('parse', function() {
 
     it('should get/set the matrix correctly for 3d matrices', function() {
       var scope = {};
-      assert.deepEqual(parseAndEval('f=[1,2;3,4]', scope), new Matrix([[1,2],[3,4]]));
-      assert.deepEqual(parseAndEval('size(f)', scope), new Matrix([2,2]));
+      assert.deepEqual(parseAndEval('f=[1,2;3,4]', scope), math.matrix([[1,2],[3,4]]));
+      assert.deepEqual(parseAndEval('size(f)', scope), math.matrix([2,2]));
 
-      assert.deepEqual(parseAndEval('f[:,:,2]=[5,6;7,8]', scope), new Matrix([
+      assert.deepEqual(parseAndEval('f[:,:,2]=[5,6;7,8]', scope), math.matrix([
         [
           [1,5],
           [2,6]
@@ -401,21 +401,21 @@ describe('parse', function() {
         ]
       ]));
 
-      assert.deepEqual(parseAndEval('size(f)', scope), new Matrix([2,2,2]));
-      assert.deepEqual(parseAndEval('f[:,:,1]', scope), new Matrix([[[1],[2]],[[3],[4]]]));
-      assert.deepEqual(parseAndEval('f[:,:,2]', scope), new Matrix([[[5],[6]],[[7],[8]]]));
-      assert.deepEqual(parseAndEval('f[:,2,:]', scope), new Matrix([[[2,6]],[[4,8]]]));
-      assert.deepEqual(parseAndEval('f[2,:,:]', scope), new Matrix([[[3,7],[4,8]]]));
+      assert.deepEqual(parseAndEval('size(f)', scope), math.matrix([2,2,2]));
+      assert.deepEqual(parseAndEval('f[:,:,1]', scope), math.matrix([[[1],[2]],[[3],[4]]]));
+      assert.deepEqual(parseAndEval('f[:,:,2]', scope), math.matrix([[[5],[6]],[[7],[8]]]));
+      assert.deepEqual(parseAndEval('f[:,2,:]', scope), math.matrix([[[2,6]],[[4,8]]]));
+      assert.deepEqual(parseAndEval('f[2,:,:]', scope), math.matrix([[[3,7],[4,8]]]));
 
       parseAndEval('a=diag([1,2,3,4])', scope);
-      assert.deepEqual(parseAndEval('a[3:end, 3:end]', scope), new Matrix([[3,0],[0,4]]));
-      assert.deepEqual(parseAndEval('a[3:end, 2:end]=9*ones(2,3)', scope), new Matrix([
+      assert.deepEqual(parseAndEval('a[3:end, 3:end]', scope), math.matrix([[3,0],[0,4]]));
+      assert.deepEqual(parseAndEval('a[3:end, 2:end]=9*ones(2,3)', scope), math.matrix([
         [1,0,0,0],
         [0,2,0,0],
         [0,9,9,9],
         [0,9,9,9]
       ]));
-      assert.deepEqual(parseAndEval('a[2:end-1, 2:end-1]', scope), new Matrix([[2,0],[9,9]]));
+      assert.deepEqual(parseAndEval('a[2:end-1, 2:end-1]', scope), math.matrix([[2,0],[9,9]]));
     });
 
     it('should merge nested matrices', function() {
@@ -428,20 +428,20 @@ describe('parse', function() {
       var scope = {};
       parseAndEval('a=[1,2;3,4]', scope);
       parseAndEval('b=[5,6;7,8]', scope);
-      assert.deepEqual(parseAndEval('c=concat(a,b)', scope), new Matrix([[1,2,5,6],[3,4,7,8]]));
-      assert.deepEqual(parseAndEval('c=concat(a,b,1)', scope), new Matrix([[1,2],[3,4],[5,6],[7,8]]));
-      assert.deepEqual(parseAndEval('c=concat(concat(a,b), concat(b,a), 1)', scope), new Matrix([[1,2,5,6],[3,4,7,8],[5,6,1,2],[7,8,3,4]]));
-      assert.deepEqual(parseAndEval('c=concat([[1,2]], [[3,4]], 1)', scope), new Matrix([[1,2],[3,4]]));
-      assert.deepEqual(parseAndEval('c=concat([[1,2]], [[3,4]], 2)', scope), new Matrix([[1,2,3,4]]));
-      assert.deepEqual(parseAndEval('c=concat([[1]], [2;3], 1)', scope), new Matrix([[1],[2],[3]]));
-      assert.deepEqual(parseAndEval('d=1:3', scope), new Matrix([1,2,3]));
-      assert.deepEqual(parseAndEval('concat(d,d)', scope), new Matrix([1,2,3,1,2,3]));
-      assert.deepEqual(parseAndEval('e=1+d', scope), new Matrix([2,3,4]));
-      assert.deepEqual(parseAndEval('size(e)', scope), new Matrix([3]));
-      assert.deepEqual(parseAndEval('concat(e,e)', scope), new Matrix([2,3,4,2,3,4]));
-      assert.deepEqual(parseAndEval('[[],[]]', scope), new Matrix([[],[]]));
+      assert.deepEqual(parseAndEval('c=concat(a,b)', scope), math.matrix([[1,2,5,6],[3,4,7,8]]));
+      assert.deepEqual(parseAndEval('c=concat(a,b,1)', scope), math.matrix([[1,2],[3,4],[5,6],[7,8]]));
+      assert.deepEqual(parseAndEval('c=concat(concat(a,b), concat(b,a), 1)', scope), math.matrix([[1,2,5,6],[3,4,7,8],[5,6,1,2],[7,8,3,4]]));
+      assert.deepEqual(parseAndEval('c=concat([[1,2]], [[3,4]], 1)', scope), math.matrix([[1,2],[3,4]]));
+      assert.deepEqual(parseAndEval('c=concat([[1,2]], [[3,4]], 2)', scope), math.matrix([[1,2,3,4]]));
+      assert.deepEqual(parseAndEval('c=concat([[1]], [2;3], 1)', scope), math.matrix([[1],[2],[3]]));
+      assert.deepEqual(parseAndEval('d=1:3', scope), math.matrix([1,2,3]));
+      assert.deepEqual(parseAndEval('concat(d,d)', scope), math.matrix([1,2,3,1,2,3]));
+      assert.deepEqual(parseAndEval('e=1+d', scope), math.matrix([2,3,4]));
+      assert.deepEqual(parseAndEval('size(e)', scope), math.matrix([3]));
+      assert.deepEqual(parseAndEval('concat(e,e)', scope), math.matrix([2,3,4,2,3,4]));
+      assert.deepEqual(parseAndEval('[[],[]]', scope), math.matrix([[],[]]));
       assert.deepEqual(parseAndEval('[[],[]]', scope).size(), [2, 0]);
-      assert.deepEqual(parseAndEval('size([[],[]])', scope), new Matrix([2, 0]));
+      assert.deepEqual(parseAndEval('size([[],[]])', scope), math.matrix([2, 0]));
     });
 
     it('should execute map on an array with one based indices', function () {
@@ -464,7 +464,7 @@ describe('parse', function() {
     it('should execute map on a Matrix with one based indices', function () {
       var logs = [];
       var scope = {
-        A: new Matrix([1,2,3]),
+        A: math.matrix([1,2,3]),
         callback: function (value, index, matrix) {
           assert.strictEqual(matrix, scope.A);
           // note: we don't copy index, index should be a new Array for every call of callback
@@ -473,7 +473,7 @@ describe('parse', function() {
         }
       };
       var res = math.eval('map(A, callback)', scope);
-      assert.deepEqual(res, new Matrix([2,3,4]));
+      assert.deepEqual(res, math.matrix([2,3,4]));
 
       assert.deepEqual(logs, [[1, [1]], [2, [2]], [3, [3]]]);
     });
@@ -496,7 +496,7 @@ describe('parse', function() {
     it('should execute forEach on a Matrix with one based indices', function () {
       var logs = [];
       var scope = {
-        A: new Matrix([1,2,3]),
+        A: math.matrix([1,2,3]),
         callback: function (value, index, matrix) {
           assert.strictEqual(matrix, scope.A);
           // note: we don't copy index, index should be a new Array for every call of callback
@@ -584,7 +584,7 @@ describe('parse', function() {
       assert.equal(scope.c, 4.5);
       assert.equal(scope.d, 4.5);
       assert.equal(scope.e, 4.5);
-      assert.deepEqual(parseAndEval('a = [1,2,f=3]', scope), new Matrix([1,2,3]));
+      assert.deepEqual(parseAndEval('a = [1,2,f=3]', scope), math.matrix([1,2,3]));
       assert.equal(scope.f, 3);
       assert.equal(parseAndEval('2 + (g = 3 + 4)', scope), 9);
       assert.equal(scope.g, 7);
@@ -697,7 +697,7 @@ describe('parse', function() {
       assert.equal(parseAndEval('4 ./ 2'), 2);
       assert.equal(parseAndEval('8 ./ 2 / 2'), 2);
 
-      assert.deepEqual(parseAndEval('[1,2,3] ./ [1,2,3]'), new Matrix([1,1,1]));
+      assert.deepEqual(parseAndEval('[1,2,3] ./ [1,2,3]'), math.matrix([1,1,1]));
     });
 
     it('should parse dotMultiply .*', function() {
@@ -708,7 +708,7 @@ describe('parse', function() {
       approx.deepEqual(parseAndEval('8 .* 2 .* 2'), 32);
       assert.deepEqual(parseAndEval('a=3; a.*4'), new ResultSet([12]));
 
-      assert.deepEqual(parseAndEval('[1,2,3] .* [1,2,3]'), new Matrix([1,4,9]));
+      assert.deepEqual(parseAndEval('[1,2,3] .* [1,2,3]'), math.matrix([1,4,9]));
     });
 
     it('should parse dotPower .^', function() {
@@ -718,13 +718,13 @@ describe('parse', function() {
       approx.deepEqual(parseAndEval('-2.^2'), -4);  // -(2^2)
       approx.deepEqual(parseAndEval('2.^3.^4'), 2.41785163922926e+24); // 2^(3^4)
 
-      assert.deepEqual(parseAndEval('[2,3] .^ [2,3]'), new Matrix([4,27]));
+      assert.deepEqual(parseAndEval('[2,3] .^ [2,3]'), math.matrix([4,27]));
     });
 
     it('should parse equal ==', function() {
       assert.strictEqual(parseAndEval('2 == 3'), false);
       assert.strictEqual(parseAndEval('2 == 2'), true);
-      assert.deepEqual(parseAndEval('[2,3] == [2,4]'), new Matrix([true, false]));
+      assert.deepEqual(parseAndEval('[2,3] == [2,4]'), math.matrix([true, false]));
     });
 
     it('should parse larger >', function() {
@@ -783,10 +783,10 @@ describe('parse', function() {
       assert.equal(parseAndEval('(2a)^3', {a:2}), 64);
       assert.equal(parseAndEval('sqrt(2a)', {a:2}), 2);
 
-      assert.deepEqual(parseAndEval('[2, 3] 2'), new Matrix([4, 6]));
-      assert.deepEqual(parseAndEval('[2, 3] a', {a:2}), new Matrix([4, 6]));
+      assert.deepEqual(parseAndEval('[2, 3] 2'), math.matrix([4, 6]));
+      assert.deepEqual(parseAndEval('[2, 3] a', {a:2}), math.matrix([4, 6]));
       assert.deepEqual(parseAndEval('[2, 3] [3, 2]', {a:2}), 12); // implicit multiplication
-      assert.deepEqual(parseAndEval('2 [2, 3]'), new Matrix([4, 6]));
+      assert.deepEqual(parseAndEval('2 [2, 3]'), math.matrix([4, 6]));
       assert.deepEqual(parseAndEval('(A) [2,2,2]', {A: [1,2,3]}), 12);  // implicit multiplication
       assert.deepEqual(parseAndEval('A [2,2]', {A: [[1,2], [3,4]]}), 4); // index, no multiplication
     });
@@ -1014,7 +1014,7 @@ describe('parse', function() {
     it('should parse unequal !=', function() {
       assert.strictEqual(parseAndEval('2 != 3'), true);
       assert.strictEqual(parseAndEval('2 != 2'), false);
-      assert.deepEqual(parseAndEval('[2,3] != [2,4]'), new Matrix([false, true]));
+      assert.deepEqual(parseAndEval('[2,3] != [2,4]'), math.matrix([false, true]));
     });
 
     it('should parse conditional expression a ? b : c', function() {
@@ -1040,17 +1040,17 @@ describe('parse', function() {
 
     it('should parse : (range)', function() {
       assert.ok(parseAndEval('2:5') instanceof Matrix);
-      assert.deepEqual(parseAndEval('2:5'), new Matrix([2,3,4,5]));
-      assert.deepEqual(parseAndEval('10:-2:0'), new Matrix([10,8,6,4,2,0]));
-      assert.deepEqual(parseAndEval('2:4.0'), new Matrix([2,3,4]));
-      assert.deepEqual(parseAndEval('2:4.5'), new Matrix([2,3,4]));
-      assert.deepEqual(parseAndEval('2:4.1'), new Matrix([2,3,4]));
-      assert.deepEqual(parseAndEval('2:3.9'), new Matrix([2,3]));
-      assert.deepEqual(parseAndEval('2:3.5'), new Matrix([2,3]));
-      assert.deepEqual(parseAndEval('3:-1:0.5'), new Matrix([3,2,1]));
-      assert.deepEqual(parseAndEval('3:-1:0.5'), new Matrix([3,2,1]));
-      assert.deepEqual(parseAndEval('3:-1:0.1'), new Matrix([3,2,1]));
-      assert.deepEqual(parseAndEval('3:-1:-0.1'), new Matrix([3,2,1,0]));
+      assert.deepEqual(parseAndEval('2:5'), math.matrix([2,3,4,5]));
+      assert.deepEqual(parseAndEval('10:-2:0'), math.matrix([10,8,6,4,2,0]));
+      assert.deepEqual(parseAndEval('2:4.0'), math.matrix([2,3,4]));
+      assert.deepEqual(parseAndEval('2:4.5'), math.matrix([2,3,4]));
+      assert.deepEqual(parseAndEval('2:4.1'), math.matrix([2,3,4]));
+      assert.deepEqual(parseAndEval('2:3.9'), math.matrix([2,3]));
+      assert.deepEqual(parseAndEval('2:3.5'), math.matrix([2,3]));
+      assert.deepEqual(parseAndEval('3:-1:0.5'), math.matrix([3,2,1]));
+      assert.deepEqual(parseAndEval('3:-1:0.5'), math.matrix([3,2,1]));
+      assert.deepEqual(parseAndEval('3:-1:0.1'), math.matrix([3,2,1]));
+      assert.deepEqual(parseAndEval('3:-1:-0.1'), math.matrix([3,2,1,0]));
     });
 
     it('should parse to', function() {
@@ -1064,23 +1064,23 @@ describe('parse', function() {
 
     it('should parse factorial !', function() {
       assert.deepEqual(parseAndEval('5!'), 120);
-      assert.deepEqual(parseAndEval('[1,2,3,4]!'), new Matrix([1,2,6,24]));
+      assert.deepEqual(parseAndEval('[1,2,3,4]!'), math.matrix([1,2,6,24]));
       assert.deepEqual(parseAndEval('4!+2'), 26);
       assert.deepEqual(parseAndEval('4!-2'), 22);
       assert.deepEqual(parseAndEval('4!*2'), 48);
       assert.deepEqual(parseAndEval('3!!'), 720);
-      assert.deepEqual(parseAndEval('[1,2;3,1]!\'!'), new Matrix([[1, 720], [2, 1]]));
+      assert.deepEqual(parseAndEval('[1,2;3,1]!\'!'), math.matrix([[1, 720], [2, 1]]));
       assert.deepEqual(parseAndEval('[4,5]![2,2]'), 24*2 + 120*2); // implicit multiplication
     });
 
     it('should parse transpose \'', function() {
       assert.deepEqual(parseAndEval('23\''), 23);
-      assert.deepEqual(parseAndEval('[1,2,3;4,5,6]\''), new Matrix([[1,4],[2,5],[3,6]]));
+      assert.deepEqual(parseAndEval('[1,2,3;4,5,6]\''), math.matrix([[1,4],[2,5],[3,6]]));
       assert.ok(parseAndEval('[1,2,3;4,5,6]\'') instanceof Matrix);
-      assert.deepEqual(parseAndEval('[1:5]'), new Matrix([[1,2,3,4,5]]));
-      assert.deepEqual(parseAndEval('[1:5]\''), new Matrix([[1],[2],[3],[4],[5]]));
-      assert.deepEqual(parseAndEval('size([1:5])'), new Matrix([1, 5]));
-      assert.deepEqual(parseAndEval('[1,2;3,4]\''), new Matrix([[1,3],[2,4]]));
+      assert.deepEqual(parseAndEval('[1:5]'), math.matrix([[1,2,3,4,5]]));
+      assert.deepEqual(parseAndEval('[1:5]\''), math.matrix([[1],[2],[3],[4],[5]]));
+      assert.deepEqual(parseAndEval('size([1:5])'), math.matrix([1, 5]));
+      assert.deepEqual(parseAndEval('[1,2;3,4]\''), math.matrix([[1,3],[2,4]]));
     });
 
     describe('operator precedence', function() {
@@ -1184,8 +1184,8 @@ describe('parse', function() {
         assert.equal(parseAndEval('3 ? 2 + 4 : 2 - 1'), 6);
         assert.deepEqual(parseAndEval('3 ? true : false; 22'), new ResultSet([22]));
         assert.deepEqual(parseAndEval('3 ? 5cm to m : 5cm in mm'), new Unit(5, 'cm').to('m'));
-        assert.deepEqual(parseAndEval('2 == 4-2 ? [1,2] : false'), new Matrix([1,2]));
-        assert.deepEqual(parseAndEval('false ? 1:2:6'), new Matrix([2,3,4,5,6]));
+        assert.deepEqual(parseAndEval('2 == 4-2 ? [1,2] : false'), math.matrix([1,2]));
+        assert.deepEqual(parseAndEval('false ? 1:2:6'), math.matrix([2,3,4,5,6]));
       });
 
       it('should respect precedence between left/right shift and relational operators', function () {
@@ -1447,9 +1447,9 @@ describe('parse', function() {
       n = parse('qq[1,1]=33');
       assert.throws(function () { n.compile(math).eval(scope); });
       parse('qq=[1,2;3,4]').compile(math).eval(scope);
-      assert.deepEqual(n.compile(math).eval(scope), new Matrix([[33,2],[3,4]]));
+      assert.deepEqual(n.compile(math).eval(scope), math.matrix([[33,2],[3,4]]));
       parse('qq=[4]').compile(math).eval(scope);
-      assert.deepEqual(n.compile(math).eval(scope), new Matrix([[33]]));
+      assert.deepEqual(n.compile(math).eval(scope), math.matrix([[33]]));
       delete scope.qq;
       assert.throws(function () { n.compile(math).eval(scope); });
     });
@@ -1505,8 +1505,8 @@ describe('parse', function() {
 
       // evaluation via parser throws one-based error
       assert.deepEqual(math.eval('max([[1,2], [3,4]])'), 4);
-      assert.deepEqual(math.eval('max([[1,2], [3,4]], 1)'), new Matrix([3, 4]));
-      assert.deepEqual(math.eval('max([[1,2], [3,4]], 2)'), new Matrix([2, 4]));
+      assert.deepEqual(math.eval('max([[1,2], [3,4]], 1)'), math.matrix([3, 4]));
+      assert.deepEqual(math.eval('max([[1,2], [3,4]], 2)'), math.matrix([2, 4]));
       assert.throws(function () {math.eval('max([[1,2], [3,4]], 3)')}, /IndexError: Index out of range \(3 > 2\)/);
       assert.throws(function () {math.eval('max([[1,2], [3,4]], 0)')}, /IndexError: Index out of range \(0 < 1\)/);
     });
@@ -1519,8 +1519,8 @@ describe('parse', function() {
 
       // evaluation via parser throws one-based error
       assert.deepEqual(math.eval('min([[1,2], [3,4]])'), 1);
-      assert.deepEqual(math.eval('min([[1,2], [3,4]], 1)'), new Matrix([1, 2]));
-      assert.deepEqual(math.eval('min([[1,2], [3,4]], 2)'), new Matrix([1, 3]));
+      assert.deepEqual(math.eval('min([[1,2], [3,4]], 1)'), math.matrix([1, 2]));
+      assert.deepEqual(math.eval('min([[1,2], [3,4]], 2)'), math.matrix([1, 3]));
       assert.throws(function () {math.eval('min([[1,2], [3,4]], 3)')}, /IndexError: Index out of range \(3 > 2\)/);
       assert.throws(function () {math.eval('min([[1,2], [3,4]], 0)')}, /IndexError: Index out of range \(0 < 1\)/);
     });
@@ -1533,8 +1533,8 @@ describe('parse', function() {
 
       // evaluation via parser throws one-based error
       assert.deepEqual(math.eval('mean([[1,2], [3,4]])'), 2.5);
-      assert.deepEqual(math.eval('mean([[1,2], [3,4]], 1)'), new Matrix([2, 3]));
-      assert.deepEqual(math.eval('mean([[1,2], [3,4]], 2)'), new Matrix([1.5, 3.5]));
+      assert.deepEqual(math.eval('mean([[1,2], [3,4]], 1)'), math.matrix([2, 3]));
+      assert.deepEqual(math.eval('mean([[1,2], [3,4]], 2)'), math.matrix([1.5, 3.5]));
       assert.throws(function () {math.eval('mean([[1,2], [3,4]], 3)')}, /IndexError: Index out of range \(3 > 2\)/);
       assert.throws(function () {math.eval('mean([[1,2], [3,4]], 0)')}, /IndexError: Index out of range \(0 < 1\)/);
     });

--- a/test/function/construction/boolean.test.js
+++ b/test/function/construction/boolean.test.js
@@ -1,5 +1,4 @@
 var assert = require('assert'),
-    error = require('../../../lib/error/index'),
     math = require('../../../index'),
     bool = math['boolean'];
 
@@ -31,7 +30,7 @@ describe('boolean', function() {
   });
 
   it('should convert the elements of a matrix or array to booleans', function() {
-    assert.deepEqual(bool(math.matrix([1,0,1,1])), new math.type.Matrix([true, false, true, true]));
+    assert.deepEqual(bool(math.matrix([1,0,1,1])), math.matrix([true, false, true, true]));
     assert.deepEqual(bool([1,0,1,1]), [true, false, true, true]);
   });
 
@@ -52,20 +51,20 @@ describe('boolean', function() {
   });
 
   it('should throw an error if the string is not a valid number', function() {
-    assert.throws(function () {bool('')}, /Error: Cannot convert/);
-    assert.throws(function () {bool('23a')}, /Error: Cannot convert/);
+    assert.throws(function () {bool('');}, /Error: Cannot convert/);
+    assert.throws(function () {bool('23a');}, /Error: Cannot convert/);
   });
 
   it('should throw an error if there\'s a wrong number of arguments', function() {
-    assert.throws(function () {bool(1,2)}, /TypeError: Too many arguments/);
+    assert.throws(function () {bool(1,2);}, /TypeError: Too many arguments/);
   });
 
   it('should throw an error if used with a complex', function() {
-    assert.throws(function () {bool(math.complex(2,3))}, /TypeError: Unexpected type of argument/);
+    assert.throws(function () {bool(math.complex(2,3));}, /TypeError: Unexpected type of argument/);
   });
 
   it('should throw an error if used with a unit', function() {  
-    assert.throws(function () {bool(math.unit('5cm'))}, /TypeError: Unexpected type of argument/);
+    assert.throws(function () {bool(math.unit('5cm'));}, /TypeError: Unexpected type of argument/);
   });
 
 });

--- a/test/function/construction/complex.test.js
+++ b/test/function/construction/complex.test.js
@@ -1,5 +1,4 @@
 var assert = require('assert'),
-    error = require('../../../lib/error/index'),
     math = require('../../../index'),
     complex = math.complex;
 
@@ -36,7 +35,7 @@ describe('complex', function() {
       new math.type.Complex(1, 0),
       new math.type.Complex(2, 3)
     ];
-    assert.deepEqual(complex(math.matrix([2, 1, complex(2, 3)])), new math.type.Matrix(result));
+    assert.deepEqual(complex(math.matrix([2, 1, complex(2, 3)])), math.matrix(result));
     assert.deepEqual(complex([2, 1, complex(2, 3)]), result);
   });
 
@@ -50,7 +49,7 @@ describe('complex', function() {
   });
 
   it('should throw an error if called with a string', function() {
-    assert.throws(function () {complex('no valid complex number')}, SyntaxError);
+    assert.throws(function () {complex('no valid complex number');}, SyntaxError);
   });
 
   it('should create a complex value from a boolean', function() {
@@ -58,7 +57,7 @@ describe('complex', function() {
   });
 
   it('should throw an error if called with a unit', function() {
-    assert.throws(function () {complex(math.unit('5cm'))}, /Error: Expected object with either properties re and im, or properties r and phi./);
+    assert.throws(function () {complex(math.unit('5cm'));}, /Error: Expected object with either properties re and im, or properties r and phi./);
   });
 
   it('should accept two numbers as arguments', function() {
@@ -69,11 +68,11 @@ describe('complex', function() {
   });
 
   it('should throw an error if passed two argument, one is invalid', function() {
-    assert.throws(function () {complex('string', 2)}, TypeError);
-    assert.throws(function () {complex(2, 'string')}, TypeError);
+    assert.throws(function () {complex('string', 2);}, TypeError);
+    assert.throws(function () {complex(2, 'string');}, TypeError);
   });
 
   it('should throw an error if called with more than 2 arguments', function() {
-    assert.throws(function () {complex(2,3,4)}, /TypeError: Too many arguments/);
+    assert.throws(function () {complex(2,3,4);}, /TypeError: Too many arguments/);
   });
 });

--- a/test/function/construction/matrix.test.js
+++ b/test/function/construction/matrix.test.js
@@ -1,6 +1,5 @@
 // test matrix construction
 var assert = require('assert'),
-    error = require('../../../lib/error/index'),
     math = require('../../../index'),
     matrix = math.matrix;
 
@@ -15,7 +14,7 @@ describe('matrix', function() {
   it('should create a matrix from an array', function() {
     var b = matrix([[1,2],[3,4]]);
     assert.ok(b instanceof math.type.Matrix);
-    assert.deepEqual(b, new math.type.Matrix([[1,2],[3,4]]));
+    assert.deepEqual(b, math.matrix([[1,2],[3,4]]));
     assert.deepEqual(math.size(b), matrix([2,2]));
   });
 
@@ -23,27 +22,27 @@ describe('matrix', function() {
     var b = matrix([[1,2],[3,4]]);
     var c = matrix(b);
     assert.ok(c._data != b._data); // data should be cloned
-    assert.deepEqual(c, new math.type.Matrix([[1,2],[3,4]]));
+    assert.deepEqual(c, math.matrix([[1,2],[3,4]]));
     assert.deepEqual(math.size(c), matrix([2,2]));
   });
 
   it('should create a matrix from a range correctly', function() {
     var d = matrix(math.range(1,6));
     assert.ok(d instanceof math.type.Matrix);
-    assert.deepEqual(d, new math.type.Matrix([1,2,3,4,5]));
+    assert.deepEqual(d, math.matrix([1,2,3,4,5]));
     assert.deepEqual(math.size(d), matrix([5]));
   });
 
   it('should throw an error if called with a single number', function() {
-    assert.throws(function () {matrix(123)}, TypeError);
+    assert.throws(function () {matrix(123);}, TypeError);
   });
 
   it('should throw an error if called with a unit', function() {
-    assert.throws(function () {matrix(math.unit('5cm'))}, TypeError);
+    assert.throws(function () {matrix(math.unit('5cm'));}, TypeError);
   });
 
   it('should throw an error if called with 2 numbers', function() {
-    assert.throws(function () {matrix([], 3)}, /TypeError: Too many arguments/);
+    assert.throws(function () {matrix([], 3);}, /TypeError: Too many arguments/);
   });
 
 });

--- a/test/function/construction/number.test.js
+++ b/test/function/construction/number.test.js
@@ -1,5 +1,4 @@
 var assert = require('assert'),
-    error = require('../../../lib/error/index'),
     math = require('../../../index'),
     approx = require('../../../tools/approx'),
     number = math.number;
@@ -41,12 +40,12 @@ describe('number', function() {
   });
 
   it('should throw an error if called with an invalid string', function() {
-    assert.throws(function () {number('2.3.4')}, SyntaxError);
-    assert.throws(function () {number('23a')}, SyntaxError);
+    assert.throws(function () {number('2.3.4');}, SyntaxError);
+    assert.throws(function () {number('23a');}, SyntaxError);
   });
 
   it('should convert the elements of a matrix to numbers', function() {
-    assert.deepEqual(number(math.matrix(['123',true])), new math.type.Matrix([123, 1]));
+    assert.deepEqual(number(math.matrix(['123',true])), math.matrix([123, 1]));
   });
 
   it('should convert the elements of an array to numbers', function() {
@@ -54,18 +53,18 @@ describe('number', function() {
   });
 
   it('should throw an error if called with a wrong number of arguments', function() {
-    assert.throws(function () {number(1,2,3)}, /TypeError: Too many arguments/);
+    assert.throws(function () {number(1,2,3);}, /TypeError: Too many arguments/);
   });
 
   it('should throw an error if called with a complex number', function() {
-    assert.throws(function () {number(math.complex(2,3))}, TypeError);
+    assert.throws(function () {number(math.complex(2,3));}, TypeError);
   });
 
   it('should throw an error with wrong type of arguments', function() {
-    assert.throws(function () {number(math.unit('5cm'))}, /Second argument with valueless unit expected/);
+    assert.throws(function () {number(math.unit('5cm'));}, /Second argument with valueless unit expected/);
     //assert.throws(function () {number(math.unit('5cm'), 2)}, TypeError); // FIXME: this should also throw an error
-    assert.throws(function () {number(math.unit('5cm'), new Date())}, TypeError);
-    assert.throws(function () {number('23', 2)}, TypeError);
+    assert.throws(function () {number(math.unit('5cm'), new Date());}, TypeError);
+    assert.throws(function () {number('23', 2);}, TypeError);
   });
 });
 

--- a/test/function/construction/string.test.js
+++ b/test/function/construction/string.test.js
@@ -1,5 +1,4 @@
 var assert = require('assert'),
-    error = require('../../../lib/error/index'),
     math = require('../../../index'),
     string = math.string;
 
@@ -30,7 +29,7 @@ describe('string', function() {
 
   it('should convert the elements of a matrix to strings', function() {
     assert.deepEqual(string(math.matrix([[2,true],['hi',null]])),
-        new math.type.Matrix([['2', 'true'],['hi', 'null']]));
+        math.matrix([['2', 'true'],['hi', 'null']]));
   });
 
   it('should convert a number to string', function() {
@@ -53,7 +52,7 @@ describe('string', function() {
   });
 
   it('should throw an error if called with wrong number of arguments', function() {
-    assert.throws(function () {string(1,2)}, /TypeError: Too many arguments/);
-    assert.throws(function () {string(1,2,3)}, /TypeError: Too many arguments/);
+    assert.throws(function () {string(1,2);}, /TypeError: Too many arguments/);
+    assert.throws(function () {string(1,2,3);}, /TypeError: Too many arguments/);
   });
 });

--- a/test/function/expression/eval.test.js
+++ b/test/function/expression/eval.test.js
@@ -4,7 +4,6 @@ var approx = require('../../../tools/approx');
 var error = require('../../../lib/error/index');
 var math = require('../../../index');
 var Complex = math.type.Complex;
-var Matrix = math.type.Matrix;
 var Unit = math.type.Unit;
 var ResultSet = math.type.ResultSet;
 
@@ -18,7 +17,7 @@ describe('eval', function() {
   it('should eval a list of expressions', function() {
     assert.deepEqual(math.eval(['1+2', '3+4', '5+6']), [3, 7, 11]);
     assert.deepEqual(math.eval(['a=3', 'b=4', 'a*b']), [3, 4, 12]);
-    assert.deepEqual(math.eval(new Matrix(['a=3', 'b=4', 'a*b'])), new Matrix([3, 4, 12]));
+    assert.deepEqual(math.eval(math.matrix(['a=3', 'b=4', 'a*b'])), math.matrix([3, 4, 12]));
     assert.deepEqual(math.eval(['a=3', 'b=4', 'a*b']), [3, 4, 12]);
   });
 
@@ -29,24 +28,24 @@ describe('eval', function() {
   });
 
   it('should throw an error if wrong number of arguments', function() {
-    assert.throws(function () {math.eval()},  error.ArgumentsError);
-    assert.throws(function () {math.eval(1,2,3)}, error.ArgumentsError);
+    assert.throws(function () {math.eval();},  error.ArgumentsError);
+    assert.throws(function () {math.eval(1,2,3);}, error.ArgumentsError);
   });
 
   it('should throw an error with a number', function() {
-    assert.throws(function () {math.eval(23)}, TypeError);
+    assert.throws(function () {math.eval(23);}, TypeError);
   });
 
   it('should throw an error with a unit', function() {
-    assert.throws(function () {math.eval(new Unit(5, 'cm'))}, TypeError);
+    assert.throws(function () {math.eval(new Unit(5, 'cm'));}, TypeError);
   });
 
   it('should throw an error with a complex number', function() {
-    assert.throws(function () {math.eval(new Complex(2,3))}, TypeError);
+    assert.throws(function () {math.eval(new Complex(2,3));}, TypeError);
   });
 
   it('should throw an error with a boolean', function() {
-    assert.throws(function () {math.eval(true)}, TypeError);
+    assert.throws(function () {math.eval(true);}, TypeError);
   });
 
   it('should handle the given scope', function() {

--- a/test/function/matrix/det.test.js
+++ b/test/function/matrix/det.test.js
@@ -14,7 +14,7 @@ describe('det', function() {
   it('should calculate correctly the determinant of a NxN matrix', function() {
     assert.equal(det([5]), 5);
     assert.equal(det([[1,2],[3,4]]), -2);
-    assert.equal(det(new Matrix([[1,2],[3,4]])), -2);
+    assert.equal(det(math.matrix([[1,2],[3,4]])), -2);
     approx.equal(det([
       [-2, 2,  3],
       [-1, 1,  3],
@@ -130,7 +130,7 @@ describe('det', function() {
 
   it('should not accept arrays with dimensions higher than 2', function() {
     assert.throws(function() { det([[[1]]]); }, RangeError);
-    assert.throws(function() { det(new Matrix([[[1]]])); }, RangeError);
+    assert.throws(function() { det(math.matrix([[[1]]])); }, RangeError);
   });
 
 });

--- a/test/function/matrix/resize.test.js
+++ b/test/function/matrix/resize.test.js
@@ -40,17 +40,17 @@ describe('resize', function() {
   });
 
   it('should resize a matrix', function() {
-    var matrix = new Matrix([[0,1,2],[3,4,5]]);
+    var matrix = math.matrix([[0,1,2],[3,4,5]]);
     assert.deepEqual(math.resize(matrix, [3, 2]),
-        new Matrix([[0,1], [3,4], [0,0]]));
-    assert.deepEqual(math.resize(matrix, new Matrix([3, 2])),
-        new Matrix([[0,1], [3,4], [0,0]]));
+        math.matrix([[0,1], [3,4], [0,0]]));
+    assert.deepEqual(math.resize(matrix, math.matrix([3, 2])),
+        math.matrix([[0,1], [3,4], [0,0]]));
 
     // content should be cloned
     var x = math.complex(2, 3);
-    var a = new Matrix([x]);
+    var a = math.matrix([x]);
     var b = math.resize(a, [2], 4);
-    assert.deepEqual(b, new Matrix([x, 4]));
+    assert.deepEqual(b, math.matrix([x, 4]));
     assert.notStrictEqual(b.valueOf()[0], x);
   });
 
@@ -60,7 +60,7 @@ describe('resize', function() {
   });
 
   it('should resize a matrix into a scalar', function() {
-    var matrix = new Matrix([[0,1,2],[3,4,5]]);
+    var matrix = math.matrix([[0,1,2],[3,4,5]]);
     assert.deepEqual(math.resize(matrix, []), 0);
   });
 
@@ -84,8 +84,8 @@ describe('resize', function() {
   });
 
   it('should resize a scalar into a matrix', function() {
-    assert.deepEqual(math.resize(2, [3], 4), new Matrix([2, 4, 4]));
-    assert.deepEqual(math.resize(2, [2,2], 4), new Matrix([[2,4], [4,4]]));
+    assert.deepEqual(math.resize(2, [3], 4), math.matrix([2, 4, 4]));
+    assert.deepEqual(math.resize(2, [2,2], 4), math.matrix([[2,4], [4,4]]));
   });
 
   it('should resize a scalar into a scalar', function() {

--- a/test/function/probability/distribution.test.js
+++ b/test/function/probability/distribution.test.js
@@ -249,7 +249,7 @@ describe('distribution', function () {
     });
 
     it('should pick numbers from the given matrix following an uniform distribution', function() {
-      var possibles = new Matrix([11, 22, 33, 44, 55]),
+      var possibles = math.matrix([11, 22, 33, 44, 55]),
           picked = [],
           count;
 
@@ -275,7 +275,7 @@ describe('distribution', function () {
 
     it('should throw an error when providing a multi dimensional matrix', function() {
       assert.throws(function () {
-        uniformDistrib.pickRandom(new Matrix([[1,2], [3,4]]));
+        uniformDistrib.pickRandom(math.matrix([[1,2], [3,4]]));
       }, /Only one dimensional vectors supported/);
     });
   });

--- a/test/function/statistics/max.test.js
+++ b/test/function/statistics/max.test.js
@@ -26,7 +26,7 @@ describe('max', function() {
   });
 
   it('should return the max element from a vector', function() {
-    assert.equal(max(new Matrix([1,3,5,2,-5])), 5);
+    assert.equal(max(math.matrix([1,3,5,2,-5])), 5);
   });
 
   it('should return the max element from a 2d matrix', function() {
@@ -35,7 +35,7 @@ describe('max', function() {
       [ 3, 0,  5],
       [-1, 11, 9]
     ]), 11);
-    assert.deepEqual(max(new Matrix([
+    assert.deepEqual(max(math.matrix([
       [ 1, 4,  7],
       [ 3, 0,  5],
       [-1, 11, 9]

--- a/test/function/statistics/mean.test.js
+++ b/test/function/statistics/mean.test.js
@@ -36,8 +36,8 @@ describe('mean', function() {
   });
 
   it('should return the mean value from a 1d matrix', function() {
-    assert.equal(mean(new Matrix([5])), 5);
-    assert.equal(mean(new Matrix([1,3,5,2,-5])), 1.2);
+    assert.equal(mean(math.matrix([5])), 5);
+    assert.equal(mean(math.matrix([1,3,5,2,-5])), 1.2);
   });
 
   it('should return the mean for each vector on the last dimension', function() {
@@ -45,7 +45,7 @@ describe('mean', function() {
       [ 2, 4],
       [ 6, 8]
     ]), 5);
-    assert.deepEqual(mean(new Matrix([
+    assert.deepEqual(mean(math.matrix([
       [ 2, 4],
       [ 6, 8]
     ])), 5);

--- a/test/function/statistics/median.test.js
+++ b/test/function/statistics/median.test.js
@@ -51,7 +51,7 @@ describe('median', function() {
   });
 
   it('should return the median from an 1d matrix', function() {
-    assert.equal(median(new Matrix([1,3,5,2,-5])), 2);
+    assert.equal(median(math.matrix([1,3,5,2,-5])), 2);
   });
 
   it('should return the median from a 2d array', function() {
@@ -62,7 +62,7 @@ describe('median', function() {
   });
 
   it('should return the median from a 2d matrix', function() {
-    approx.equal(median(new Matrix([
+    approx.equal(median(math.matrix([
       [ 1, 4,  7],
       [ 3, 0,  5]
     ])), 3.5);

--- a/test/function/statistics/min.test.js
+++ b/test/function/statistics/min.test.js
@@ -1,8 +1,6 @@
 var assert = require('assert');
 var BigNumber = require('decimal.js');
 var Complex = require('../../../lib/type/Complex');
-var Matrix = require('../../../lib/type/Matrix');
-var Unit = require('../../../lib/type/Unit');
 var math = require('../../../index');
 var min = math.min;
 
@@ -30,7 +28,7 @@ describe('min', function() {
   });
 
   it('should return the min element from a vector array', function() {
-    assert.equal(min(new Matrix([1,3,5,-5,2])), -5);
+    assert.equal(min(math.matrix([1,3,5,-5,2])), -5);
   });
 
   it('should return the max element from a 2d matrix', function() {
@@ -39,7 +37,7 @@ describe('min', function() {
       [ 3, 0,  5],
       [-1, 9, 11]
     ]), -1);
-    assert.deepEqual(min(new Matrix([
+    assert.deepEqual(min(math.matrix([
       [ 1, 4,  7],
       [ 3, 0,  5],
       [-1, 9, 11]
@@ -78,27 +76,27 @@ describe('min', function() {
   });
 
   it('should throw an error when called with complex numbers', function() {
-    assert.throws(function () {min(new Complex(2,3), new Complex(2,1))}, TypeError);
-    assert.throws(function () {min(new Complex(2,3), new Complex(2,5))}, TypeError);
+    assert.throws(function () {min(new Complex(2,3), new Complex(2,1));}, TypeError);
+    assert.throws(function () {min(new Complex(2,3), new Complex(2,5));}, TypeError);
 
-    assert.throws(function () {min(new Complex(3,4), 4)}, TypeError);
-    assert.throws(function () {min(new Complex(3,4), 5)}, TypeError);
-    assert.throws(function () {min(5, new Complex(3,4))}, TypeError);
-    assert.throws(function () {min(new Complex(3,4), 6)}, TypeError);
+    assert.throws(function () {min(new Complex(3,4), 4);}, TypeError);
+    assert.throws(function () {min(new Complex(3,4), 5);}, TypeError);
+    assert.throws(function () {min(5, new Complex(3,4));}, TypeError);
+    assert.throws(function () {min(new Complex(3,4), 6);}, TypeError);
   });
 
   it('should throw an error if called a dimension out of range', function() {
-    assert.throws(function() {min([1,2,3], -1)}, /IndexError: Index out of range \(-1 < 0\)/);
-    assert.throws(function() {min([1,2,3], 1)}, /IndexError: Index out of range \(1 > 0\)/);
+    assert.throws(function() {min([1,2,3], -1);}, /IndexError: Index out of range \(-1 < 0\)/);
+    assert.throws(function() {min([1,2,3], 1);}, /IndexError: Index out of range \(1 > 0\)/);
   });
 
   it('should throw an error if called with invalid number of arguments', function() {
-    assert.throws(function() {min()});
-    assert.throws(function() {min([], 2, 3)});
+    assert.throws(function() {min();});
+    assert.throws(function() {min([], 2, 3);});
   });
 
   it('should throw an error if called with an empty array', function() {
-    assert.throws(function() {min([])});
+    assert.throws(function() {min([]);});
   });
 
 });

--- a/test/function/statistics/prod.test.js
+++ b/test/function/statistics/prod.test.js
@@ -1,8 +1,6 @@
 var assert = require('assert');
 var BigNumber = require('decimal.js');
 var Complex = require('../../../lib/type/Complex');
-var Matrix = require('../../../lib/type/Matrix');
-var Unit = require('../../../lib/type/Unit');
 var math = require('../../../index');
 var prod = math.prod;
 
@@ -34,7 +32,7 @@ describe('prod', function() {
   });
 
   it('should return the prod from an 1d matrix', function() {
-    assert.equal(prod(new Matrix([1,3,5,2])), 30);
+    assert.equal(prod(math.matrix([1,3,5,2])), 30);
   });
 
   it('should return the prod element from a 2d array', function() {
@@ -45,23 +43,23 @@ describe('prod', function() {
   });
 
   it('should return the prod element from a 2d matrix', function() {
-    assert.deepEqual(prod(new Matrix([
+    assert.deepEqual(prod(math.matrix([
       [ 1, 7, 2],
       [ 3, 5, 4]
     ])), 840);
   });
 
   it('should throw an error if called with invalid number of arguments', function() {
-    assert.throws(function() {prod()});
-    assert.throws(function() {prod([], 2, 3)});
+    assert.throws(function() {prod();});
+    assert.throws(function() {prod([], 2, 3);});
   });
 
   it('should throw an error if called with not yet supported argument dim', function() {
-    assert.throws(function() {prod([], 2)}, /not yet supported/);
+    assert.throws(function() {prod([], 2);}, /not yet supported/);
   });
 
   it('should throw an error if called with an empty array', function() {
-    assert.throws(function() {prod([])});
+    assert.throws(function() {prod([]);});
   });
 
 });

--- a/test/function/statistics/std.test.js
+++ b/test/function/statistics/std.test.js
@@ -2,7 +2,6 @@ var assert = require('assert');
 var approx = require('../../../tools/approx');
 var BigNumber = require('decimal.js');
 var Complex = require('../../../lib/type/Complex');
-var Matrix = require('../../../lib/type/Matrix');
 var Unit = require('../../../lib/type/Unit');
 var math = require('../../../index');
 var std = math.std;
@@ -44,12 +43,12 @@ describe('std', function() {
   });
 
   it('should throw an error in case of unknown type of normalization', function() {
-    assert.throws(function () {std([2,8], 'foo')}, /Unknown normalization/);
+    assert.throws(function () {std([2,8], 'foo');}, /Unknown normalization/);
   });
 
   it('should return the standard deviation from an 1d matrix', function() {
-    assert.equal(std(new Matrix([2,4,6])), 2);
-    assert.equal(std(new Matrix([5])), 0);
+    assert.equal(std(math.matrix([2,4,6])), 2);
+    assert.equal(std(math.matrix([5])), 0);
   });
 
   it('should return the standard deviation element from a 2d array', function() {
@@ -60,25 +59,25 @@ describe('std', function() {
   });
 
   it('should return the standard deviation element from a 2d matrix', function() {
-    assert.deepEqual(std(new Matrix([
+    assert.deepEqual(std(math.matrix([
       [2,4,6],
       [1,3,5]
     ])), Math.sqrt(3.5));
   });
 
   it('should throw an error if called with invalid number of arguments', function() {
-    assert.throws(function() {std()});
-    assert.throws(function() {std([], 2, 3)});
+    assert.throws(function() {std();});
+    assert.throws(function() {std([], 2, 3);});
   });
 
   it('should throw an error if called with invalid type of arguments', function() {
-    assert.throws(function() {std('a', 'b')}, TypeError);
-    assert.throws(function() {std(new Unit('5cm'), new Unit('10cm'))}, TypeError);
-    assert.throws(function() {std([2,3,4], 5)}, /Unknown normalization "5"/);
+    assert.throws(function() {std('a', 'b');}, TypeError);
+    assert.throws(function() {std(new Unit('5cm'), new Unit('10cm'));}, TypeError);
+    assert.throws(function() {std([2,3,4], 5);}, /Unknown normalization "5"/);
   });
 
   it('should throw an error if called with an empty array', function() {
-    assert.throws(function() {std([])});
+    assert.throws(function() {std([]);});
   });
 
 });

--- a/test/function/statistics/sum.test.js
+++ b/test/function/statistics/sum.test.js
@@ -1,7 +1,6 @@
 var assert = require('assert');
 var BigNumber = require('decimal.js');
 var Complex = require('../../../lib/type/Complex');
-var Matrix = require('../../../lib/type/Matrix');
 var Unit = require('../../../lib/type/Unit');
 var math = require('../../../index');
 var sum = math.sum;
@@ -43,7 +42,7 @@ describe('sum', function() {
   });
 
   it('should return the sum from an 1d matrix', function() {
-    assert.equal(sum(new Matrix([1,3,5,2,-5])), 6);
+    assert.equal(sum(math.matrix([1,3,5,2,-5])), 6);
   });
 
   it('should return the sum element from a 2d array', function() {
@@ -55,7 +54,7 @@ describe('sum', function() {
   });
 
   it('should return the sum element from a 2d matrix', function() {
-    assert.deepEqual(sum(new Matrix([
+    assert.deepEqual(sum(math.matrix([
       [ 1, 4,  7],
       [ 3, 0,  5],
       [-1, 11, 9]
@@ -63,16 +62,16 @@ describe('sum', function() {
   });
 
   it('should throw an error if called with invalid number of arguments', function() {
-    assert.throws(function() {sum()});
-    assert.throws(function() {sum([], 2, 3)});
+    assert.throws(function() {sum();});
+    assert.throws(function() {sum([], 2, 3);});
   });
 
   it('should throw an error if called with not yet supported argument dim', function() {
-    assert.throws(function() {sum([], 2)}, /not yet supported/);
+    assert.throws(function() {sum([], 2);}, /not yet supported/);
   });
 
   it('should throw an error if called with an empty array', function() {
-    assert.throws(function() {sum([])});
+    assert.throws(function() {sum([]);});
   });
 
 });

--- a/test/function/statistics/var.test.js
+++ b/test/function/statistics/var.test.js
@@ -1,7 +1,6 @@
 var assert = require('assert');
 var BigNumber = require('decimal.js');
 var Complex = require('../../../lib/type/Complex');
-var Matrix = require('../../../lib/type/Matrix');
 var Unit = require('../../../lib/type/Unit');
 var math = require('../../../index');
 var variance = math['var'];
@@ -42,12 +41,12 @@ describe('variance', function() {
   });
 
   it('should throw an error in case of unknown type of normalization', function() {
-    assert.throws(function () {variance([2,8], 'foo')}, /Unknown normalization/);
+    assert.throws(function () {variance([2,8], 'foo');}, /Unknown normalization/);
   });
 
   it('should return the variance from an 1d matrix', function() {
-    assert.equal(variance(new Matrix([2,4,6])), 4);
-    assert.equal(variance(new Matrix([5])), 0);
+    assert.equal(variance(math.matrix([2,4,6])), 4);
+    assert.equal(variance(math.matrix([5])), 0);
   });
 
   it('should return the variance element from a 2d array', function() {
@@ -58,25 +57,25 @@ describe('variance', function() {
   });
 
   it('should return the variance element from a 2d matrix', function() {
-    assert.deepEqual(variance(new Matrix([
+    assert.deepEqual(variance(math.matrix([
       [2,4,6],
       [1,3,5]
     ])), 3.5);
   });
 
   it('should throw an error if called with invalid number of arguments', function() {
-    assert.throws(function() {variance()});
-    assert.throws(function() {variance([], 2, 3)});
+    assert.throws(function() {variance();});
+    assert.throws(function() {variance([], 2, 3);});
   });
 
   it('should throw an error if called with invalid type of arguments', function() {
-    assert.throws(function() {variance('a', 'b')}, TypeError);
-    assert.throws(function() {variance(new Unit('5cm'), new Unit('10cm'))}, TypeError);
-    assert.throws(function() {variance([2,3,4], 5)}, /Unknown normalization "5"/);
+    assert.throws(function() {variance('a', 'b');}, TypeError);
+    assert.throws(function() {variance(new Unit('5cm'), new Unit('10cm'));}, TypeError);
+    assert.throws(function() {variance([2,3,4], 5);}, /Unknown normalization "5"/);
   });
 
   it('should throw an error if called with an empty array', function() {
-    assert.throws(function() {variance([])});
+    assert.throws(function() {variance([]);});
   });
 
 });

--- a/test/function/units/to.test.js
+++ b/test/function/units/to.test.js
@@ -2,7 +2,6 @@ var assert = require('assert'),
     approx = require('../../../tools/approx'),
     math = require('../../../index'),
     Unit = require('../../../lib/type/Unit'),
-    Matrix = require('../../../lib/type/Matrix'),
     unit = math.unit;
 
 describe('to', function() {
@@ -45,21 +44,21 @@ describe('to', function() {
     var b = math.to(a, unit('mm'));
 
     assert.ok(b instanceof math.type.Matrix);
-    approx.deepEqual(b, new Matrix([
+    approx.deepEqual(b, math.matrix([
       [new Unit(10, 'mm').to('mm'), new Unit(20, 'mm').to('mm')],
       [new Unit(30, 'mm').to('mm'), new Unit(40, 'mm').to('mm')]
     ]));
   });
 
   it('should throw an error if converting between incompatible units', function() {
-    assert.throws(function () {math.to(unit('20 kg'), unit('cm'))});
-    assert.throws(function () {math.to(unit('20 celsius'), unit('litre'))});
-    assert.throws(function () {math.to(unit('5 cm'), unit('2 m'))});
+    assert.throws(function () {math.to(unit('20 kg'), unit('cm'));});
+    assert.throws(function () {math.to(unit('20 celsius'), unit('litre'));});
+    assert.throws(function () {math.to(unit('5 cm'), unit('2 m'));});
   });
 
   it('should throw an error if called with a wrong number of arguments', function() {
-    assert.throws(function () {math.to(unit('20 kg'))});
-    assert.throws(function () {math.to(unit('20 kg'), unit('m'), unit('cm'))});
+    assert.throws(function () {math.to(unit('20 kg'));});
+    assert.throws(function () {math.to(unit('20 kg'), unit('m'), unit('cm'));});
   });
 
   it('should throw an error if called with a non-plain unit', function() {
@@ -67,12 +66,12 @@ describe('to', function() {
   });
 
   it('should throw an error if called with a number', function() {
-    assert.throws(function () {math.to(5, unit('m'))}, TypeError);
-    assert.throws(function () {math.to(unit('5cm'), 2)}, /SyntaxError: Unknown unit "2"/);
+    assert.throws(function () {math.to(5, unit('m'));}, TypeError);
+    assert.throws(function () {math.to(unit('5cm'), 2);}, /SyntaxError: Unknown unit "2"/);
   });
 
   it('should throw an error if called with a string', function() {
-    assert.throws(function () {math.to('5cm', unit('cm'))}, TypeError);
+    assert.throws(function () {math.to('5cm', unit('cm'));}, TypeError);
   });
 
 });

--- a/test/function/utils/typeof.test.js
+++ b/test/function/utils/typeof.test.js
@@ -1,9 +1,7 @@
 // test typeof
 var assert = require('assert'),
-    error = require('../../../lib/error/index'),
     Index = require('../../../lib/type/Index'),
     Range = require('../../../lib/type/Range'),
-    Matrix = require('../../../lib/type/Matrix'),
     Help = require('../../../lib/type/Help'),
     Unit = require('../../../lib/type/Unit'),
     Complex = require('../../../lib/type/Complex'),
@@ -43,7 +41,7 @@ describe('typeof', function() {
 
   it('should return matrix type for a matrix', function() {  
     assert.equal(math.typeof(math.matrix()), 'matrix');
-    assert.equal(math.typeof(new Matrix()), 'matrix');
+    assert.equal(math.typeof(math.matrix()), 'matrix');
   });
 
   it('should return unit type for a unit', function() {

--- a/test/json/replacer.test.js
+++ b/test/json/replacer.test.js
@@ -2,11 +2,11 @@ var assert= require('assert');
 var Complex = require('../../lib/type/Complex');
 var Range = require('../../lib/type/Range');
 var Index = require('../../lib/type/Index');
-var Matrix = require('../../lib/type/Matrix');
 var Unit = require('../../lib/type/Unit');
 var Help = require('../../lib/type/Help');
 var BigNumber = require('../../lib/type/BigNumber');
 var ResultSet = require('../../lib/type/ResultSet');
+var math = require('../../index');
 
 describe('replacer', function () {
 
@@ -58,7 +58,7 @@ describe('replacer', function () {
   });
 
   it('should stringify a Matrix', function () {
-    var m = new Matrix([[1,2],[3,4]]);
+    var m = math.matrix([[1,2],[3,4]]);
     var json = '{"mathjs":"Matrix","data":[[1,2],[3,4]]}';
 
     assert.deepEqual(JSON.stringify(m), json);
@@ -72,7 +72,7 @@ describe('replacer', function () {
 
   it('should stringify a Matrix containing a complex number', function () {
     var c = new Complex(4, 5);
-    var m = new Matrix([[1,2],[3,c]]);
+    var m = math.matrix([[1,2],[3,c]]);
     var json = '{"mathjs":"Matrix","data":[[1,2],[3,{"mathjs":"Complex","re":4,"im":5}]]}';
 
     assert.deepEqual(JSON.stringify(m), json);

--- a/test/json/reviver.test.js
+++ b/test/json/reviver.test.js
@@ -8,6 +8,7 @@ var Matrix = require('../../lib/type/Matrix');
 var BigNumber = require('../../lib/type/BigNumber');
 var Help = require('../../lib/type/Help');
 var ResultSet = require('../../lib/type/ResultSet');
+var math = require('../../index');
 
 describe('reviver', function () {
 
@@ -102,7 +103,7 @@ describe('reviver', function () {
 
   it('should parse a stringified Matrix', function () {
     var json = '{"mathjs":"Matrix","data":[[1,2],[3,4]]}';
-    var m = new Matrix([[1,2],[3,4]]);
+    var m = math.matrix([[1,2],[3,4]]);
 
     var obj = JSON.parse(json, reviver);
 
@@ -113,7 +114,7 @@ describe('reviver', function () {
   it('should parse a stringified Matrix containing a complex number', function () {
     var json = '{"mathjs":"Matrix","data":[[1,2],[3,{"mathjs":"Complex","re":4,"im":5}]]}';
     var c = new Complex(4, 5);
-    var m = new Matrix([[1,2],[3,c]]);
+    var m = math.matrix([[1,2],[3,c]]);
 
     var obj = JSON.parse(json, reviver);
 

--- a/test/type/Index.test.js
+++ b/test/type/Index.test.js
@@ -1,8 +1,8 @@
 // test data type Index
 var assert = require('assert');
 var Index = require('../../lib/type/Index');
-var Matrix = require('../../lib/type/Matrix');
 var Range = require('../../lib/type/Range');
+var math = require('../../index');
 
 describe('Index', function () {
 
@@ -22,7 +22,7 @@ describe('Index', function () {
   });
 
   it('should create an Index from a Matrix', function () {
-    assert.deepEqual(new Index(new Matrix([0, 10]))._ranges, [{start:0, end:10, step:1}]);
+    assert.deepEqual(new Index(math.matrix([0, 10]))._ranges, [{start:0, end:10, step:1}]);
   });
 
   it('should create an Index from an array with ranges', function () {
@@ -140,7 +140,7 @@ describe('Index', function () {
 
   it('should test whether an object is an Index', function () {
     assert.equal(Index.isIndex(new Index()), true);
-    assert.equal(Index.isIndex(new Matrix()), false);
+    assert.equal(Index.isIndex(math.matrix()), false);
     assert.equal(Index.isIndex(23.4), false);
     assert.equal(Index.isIndex([]), false);
     assert.equal(Index.isIndex({}), false);
@@ -178,13 +178,13 @@ describe('Index', function () {
   });
 
   it('should throw an error on non-integer ranges', function () {
-    assert.throws(function () {new Index([0,4.5])});
-    assert.throws(function () {new Index([0.1,4])});
-    assert.throws(function () {new Index([4,2,0.1])});
+    assert.throws(function () {new Index([0,4.5]);});
+    assert.throws(function () {new Index([0.1,4]);});
+    assert.throws(function () {new Index([4,2,0.1]);});
   });
 
   it('should throw an error on unsupported type of arguments', function () {
-    assert.throws(function () {new Index('string')}, TypeError);
-    assert.throws(function () {new Index(new Date())}, TypeError);
+    assert.throws(function () {new Index('string');}, TypeError);
+    assert.throws(function () {new Index(new Date());}, TypeError);
   });
 });

--- a/test/type/Matrix.test.js
+++ b/test/type/Matrix.test.js
@@ -2,34 +2,33 @@ var assert = require('assert');
 var math = require('../../index');
 var index = math.index;
 var Matrix = require('../../lib/type/Matrix');
-var Complex = require('../../lib/type/Complex');
 
 describe('matrix', function() {
 
   describe('constructor', function() {
 
     it('should build an empty if called with no argument', function() {
-      var m = new Matrix();
+      var m = math.matrix();
       assert.deepEqual(m.toArray(), []);
     });
 
     it('should create a matrix from an other matrix', function () {
-      var m = new Matrix([1,2,3]);
-      var n = new Matrix(m);
+      var m = math.matrix([1,2,3]);
+      var n = math.matrix(m);
 
       m.resize([0]); // empty matrix m to ensure n is a clone
 
-      assert.deepEqual(n, new Matrix([1,2,3]));
+      assert.deepEqual(n, math.matrix([1,2,3]));
     });
 
     it('should create a matrix an array containing matrices', function () {
-      var m = new Matrix([new Matrix([1,2]), new Matrix([3, 4])]);
+      var m = math.matrix([math.matrix([1,2]), math.matrix([3, 4])]);
 
-      assert.deepEqual(m, new Matrix([[1,2],[3, 4]]));
+      assert.deepEqual(m, math.matrix([[1,2],[3, 4]]));
     });
 
     it('should throw an error when called without new keyword', function () {
-      assert.throws(function () {Matrix()}, /Constructor must be called with the new operator/);
+      assert.throws(function () {Matrix();}, /Constructor must be called with the new operator/);
     });
 
   });
@@ -37,25 +36,25 @@ describe('matrix', function() {
   describe('size', function() {
 
     it('should return the expected size', function() {
-      assert.deepEqual(new Matrix().size(), [0]);
-      assert.deepEqual(new Matrix([[23]]).size(), [1,1]);
-      assert.deepEqual(new Matrix([[1,2,3],[4,5,6]]).size(), [2,3]);
-      assert.deepEqual(new Matrix([1,2,3]).size(), [3]);
-      assert.deepEqual(new Matrix([[1],[2],[3]]).size(), [3,1]);
-      assert.deepEqual(new Matrix([[[1],[2],[3]]]).size(), [1,3,1]);
-      assert.deepEqual(new Matrix([[[3]]]).size(), [1,1,1]);
-      assert.deepEqual(new Matrix([[]]).size(), [1,0]);
+      assert.deepEqual(math.matrix().size(), [0]);
+      assert.deepEqual(math.matrix([[23]]).size(), [1,1]);
+      assert.deepEqual(math.matrix([[1,2,3],[4,5,6]]).size(), [2,3]);
+      assert.deepEqual(math.matrix([1,2,3]).size(), [3]);
+      assert.deepEqual(math.matrix([[1],[2],[3]]).size(), [3,1]);
+      assert.deepEqual(math.matrix([[[1],[2],[3]]]).size(), [1,3,1]);
+      assert.deepEqual(math.matrix([[[3]]]).size(), [1,1,1]);
+      assert.deepEqual(math.matrix([[]]).size(), [1,0]);
     });
 
   });
 
   it('toString', function() {
-    assert.equal(new Matrix([[1,2],[3,4]]).toString(), '[[1, 2], [3, 4]]');
-    assert.equal(new Matrix([[1,2],[3,1/3]]).toString(), '[[1, 2], [3, 0.3333333333333333]]');
+    assert.equal(math.matrix([[1,2],[3,4]]).toString(), '[[1, 2], [3, 4]]');
+    assert.equal(math.matrix([[1,2],[3,1/3]]).toString(), '[[1, 2], [3, 0.3333333333333333]]');
   });
 
   it('toJSON', function() {
-    assert.deepEqual(new Matrix([[1,2],[3,4]]).toJSON(), {
+    assert.deepEqual(math.matrix([[1,2],[3,4]]).toJSON(), {
       'mathjs': 'Matrix',
       data: [[1,2],[3,4]]
     });
@@ -77,15 +76,15 @@ describe('matrix', function() {
   });
 
   it('format', function() {
-    assert.equal(new Matrix([[1,2],[3,1/3]]).format(), '[[1, 2], [3, 0.3333333333333333]]');
-    assert.equal(new Matrix([[1,2],[3,1/3]]).format(3), '[[1, 2], [3, 0.333]]');
-    assert.equal(new Matrix([[1,2],[3,1/3]]).format(4), '[[1, 2], [3, 0.3333]]');
+    assert.equal(math.matrix([[1,2],[3,1/3]]).format(), '[[1, 2], [3, 0.3333333333333333]]');
+    assert.equal(math.matrix([[1,2],[3,1/3]]).format(3), '[[1, 2], [3, 0.333]]');
+    assert.equal(math.matrix([[1,2],[3,1/3]]).format(4), '[[1, 2], [3, 0.3333]]');
   });
 
   describe('resize', function() {
 
     it('should resize the matrix correctly', function() {
-      var m = new Matrix([[1,2,3],[4,5,6]]);
+      var m = math.matrix([[1,2,3],[4,5,6]]);
       m.resize([2,4]);
       assert.deepEqual(m.valueOf(), [[1,2,3,0], [4,5,6,0]]);
 
@@ -98,7 +97,7 @@ describe('matrix', function() {
       m.resize([2,3], 9);
       assert.deepEqual(m.valueOf(), [[1,2, 9], [9,9,9]]);
 
-      m = new Matrix();
+      m = math.matrix();
       m.resize([3,3,3], 6);
       assert.deepEqual(m.valueOf(), [
         [[6,6,6],[6,6,6],[6,6,6]],
@@ -114,14 +113,14 @@ describe('matrix', function() {
     });
 
     it('should resize the matrix with uninitialized default value', function() {
-      var m = new Matrix([]);
+      var m = math.matrix([]);
       m.resize([3], math.uninitialized);
       assert.deepEqual(m.valueOf(), arr(uninit, uninit, uninit));
     });
   });
 
   describe('get', function() {
-    var m = new Matrix([[0, 1], [2, 3]]);
+    var m = math.matrix([[0, 1], [2, 3]]);
 
     it('should get a value from the matrix', function() {
       assert.equal(m.get([1,0]), 2);
@@ -129,66 +128,66 @@ describe('matrix', function() {
     });
 
     it('should throw an error when getting a value out of range', function() {
-      assert.throws(function () {m.get([3,0])});
-      assert.throws(function () {m.get([1,5])});
-      assert.throws(function () {m.get([1])});
-      assert.throws(function () {m.get([])});
+      assert.throws(function () {m.get([3,0]);});
+      assert.throws(function () {m.get([1,5]);});
+      assert.throws(function () {m.get([1]);});
+      assert.throws(function () {m.get([]);});
     });
 
     it('should throw an error in case of dimension mismatch', function() {
-      assert.throws(function () {m.get([0,2,0,2,0,2])}, /Dimension mismatch/);
+      assert.throws(function () {m.get([0,2,0,2,0,2]);}, /Dimension mismatch/);
     });
 
     it('should throw an error when getting a value given a invalid index', function() {
-      assert.throws(function () {m.get([1.2, 2])});
-      assert.throws(function () {m.get([1,-2])});
-      assert.throws(function () {m.get(1,1)});
-      assert.throws(function () {m.get(math.index(1,1))});
-      assert.throws(function () {m.get([[1,1]])});
+      assert.throws(function () {m.get([1.2, 2]);});
+      assert.throws(function () {m.get([1,-2]);});
+      assert.throws(function () {m.get(1,1);});
+      assert.throws(function () {m.get(math.index(1,1));});
+      assert.throws(function () {m.get([[1,1]]);});
     });
 
   });
 
   describe('set', function() {
     it('should set a value in a matrix', function() {
-      var m = new Matrix([[0, 0], [0, 0]]);
+      var m = math.matrix([[0, 0], [0, 0]]);
       m.set([1,0], 5);
-      assert.deepEqual(m, new Matrix([
+      assert.deepEqual(m, math.matrix([
         [0, 0],
         [5, 0]
       ]));
 
       m.set([0, 2], 4);
-      assert.deepEqual(m, new Matrix([
+      assert.deepEqual(m, math.matrix([
         [0, 0, 4],
         [5, 0, 0]
       ]));
 
       m.set([0,0,1], 3);
-      assert.deepEqual(m, new Matrix([
+      assert.deepEqual(m, math.matrix([
         [[0,3], [0,0], [4,0]],
         [[5,0], [0,0], [0,0]]
       ]));
     });
 
     it('should set a value in a matrix with defaultValue for new elements', function() {
-      var m = new Matrix();
+      var m = math.matrix();
       var defaultValue = 0;
       m.set([2], 4, defaultValue);
-      assert.deepEqual(m, new Matrix([0, 0, 4]));
+      assert.deepEqual(m, math.matrix([0, 0, 4]));
     });
 
     it('should throw an error when setting a value given a invalid index', function() {
-      var m = new Matrix([[0, 0], [0, 0]]);
-      assert.throws(function() {m.set([2.5,0], 5)});
-      assert.throws(function() {m.set([1], 5)});
-      assert.throws(function() {m.set([-1, 1], 5)});
-      assert.throws(function() {m.set(math.index([0,0]), 5)});
+      var m = math.matrix([[0, 0], [0, 0]]);
+      assert.throws(function() {m.set([2.5,0], 5);});
+      assert.throws(function() {m.set([1], 5);});
+      assert.throws(function() {m.set([-1, 1], 5);});
+      assert.throws(function() {m.set(math.index([0,0]), 5);});
     });
 
   });
 
-  // TODO: replace all assert.deepEqual(a.valueOf(), [...]) with assert.deepEqual(a, new Matrix([...]))
+  // TODO: replace all assert.deepEqual(a.valueOf(), [...]) with assert.deepEqual(a, math.matrix([...]))
 
   describe('get subset', function() {
 
@@ -196,12 +195,12 @@ describe('matrix', function() {
       var m;
 
       // get 1-dimensional
-      m = new Matrix(math.range(0,10));
+      m = math.matrix(math.range(0,10));
       assert.deepEqual(m.size(), [10]);
       assert.deepEqual(m.subset(index([2,5])).valueOf(), [2,3,4]);
 
       // get 2-dimensional
-      m = new Matrix([[1,2,3],[4,5,6],[7,8,9]]);
+      m = math.matrix([[1,2,3],[4,5,6],[7,8,9]]);
       assert.deepEqual(m.size(), [3,3]);
       assert.deepEqual(m.subset(index(1,1)), 5);
       assert.deepEqual(m.subset(index([0,2],[0,2])).valueOf(), [[1,2],[4,5]]);
@@ -211,7 +210,7 @@ describe('matrix', function() {
       assert.deepEqual(m.subset(index([1,3], 2)).valueOf(), [[6],[9]]);
 
       // get n-dimensional
-      m = new Matrix([[[1,2],[3,4]], [[5,6],[7,8]]]);
+      m = math.matrix([[[1,2],[3,4]], [[5,6],[7,8]]]);
       assert.deepEqual(m.size(), [2,2,2]);
       assert.deepEqual(m.subset(index([0,2],[0,2],[0,2])).valueOf(), m.valueOf());
       assert.deepEqual(m.subset(index(0,0,0)), 1);
@@ -222,36 +221,36 @@ describe('matrix', function() {
     });
 
     it('should squeeze the output when index contains a scalar', function() {
-      var m = new Matrix(math.range(0,10));
+      var m = math.matrix(math.range(0,10));
       assert.deepEqual(m.subset(index(1)), 1);
-      assert.deepEqual(m.subset(index([1,2])), new Matrix([1]));
+      assert.deepEqual(m.subset(index([1,2])), math.matrix([1]));
 
-      m = new Matrix([[1,2], [3,4]]);
+      m = math.matrix([[1,2], [3,4]]);
       assert.deepEqual(m.subset(index(1,1)), 4);
-      assert.deepEqual(m.subset(index([1,2], 1)), new Matrix([[4]]));
-      assert.deepEqual(m.subset(index(1, [1,2])), new Matrix([[4]]));
-      assert.deepEqual(m.subset(index([1,2], [1,2])), new Matrix([[4]]));
+      assert.deepEqual(m.subset(index([1,2], 1)), math.matrix([[4]]));
+      assert.deepEqual(m.subset(index(1, [1,2])), math.matrix([[4]]));
+      assert.deepEqual(m.subset(index([1,2], [1,2])), math.matrix([[4]]));
     });
 
     it('should throw an error if the given subset is invalid', function() {
-      var m = new Matrix();
+      var m = math.matrix();
       assert.throws(function () { m.subset([-1]); });
 
-      m = new Matrix([[1,2,3],[4,5,6]]);
+      m = math.matrix([[1,2,3],[4,5,6]]);
       assert.throws(function () { m.subset([1,2,3]); });
       assert.throws(function () { m.subset([3,0]); });
       assert.throws(function () { m.subset([1]); });
     });
 
     it('should throw an error in case of wrong number of arguments', function() {
-      var m = new Matrix();
+      var m = math.matrix();
       assert.throws(function () { m.subset();}, /Wrong number of arguments/);
       assert.throws(function () { m.subset(1,2,3,4); }, /Wrong number of arguments/);
     });
 
     it('should throw an error in case of dimension mismatch', function() {
-      var m = new Matrix([[1,2,3],[4,5,6]]);
-      assert.throws(function () {m.subset(index([0,2]))}, /Dimension mismatch/);
+      var m = math.matrix([[1,2,3],[4,5,6]]);
+      assert.throws(function () {m.subset(index([0,2]));}, /Dimension mismatch/);
     });
 
   });
@@ -260,41 +259,41 @@ describe('matrix', function() {
 
     it('should set the given subset', function() {
       // set 1-dimensional
-      var m = new Matrix(math.range(0,7));
+      var m = math.matrix(math.range(0,7));
       m.subset(index([2,4]), [20,30]);
-      assert.deepEqual(m, new Matrix([0,1,20,30,4,5,6]));
+      assert.deepEqual(m, math.matrix([0,1,20,30,4,5,6]));
       m.subset(index(4), 40);
-      assert.deepEqual(m, new Matrix([0,1,20,30,40,5,6]));
+      assert.deepEqual(m, math.matrix([0,1,20,30,40,5,6]));
 
       // set 2-dimensional
-      m = new Matrix();
+      m = math.matrix();
       m.resize([3,3]);
-      assert.deepEqual(m, new Matrix([
+      assert.deepEqual(m, math.matrix([
         [0, 0, 0],
         [0, 0, 0],
         [0, 0, 0]
       ]));
       m.subset(index([1,3], [1,3]), [[1,2],[3,4]]);
-      assert.deepEqual(m, new Matrix([
+      assert.deepEqual(m, math.matrix([
         [0, 0, 0],
         [0, 1, 2],
         [0, 3, 4]]));
       m.subset(index(0, [0,3]), [5,6,7]);
-      assert.deepEqual(m, new Matrix([[5,6,7],[0,1,2],[0,3,4]]));
+      assert.deepEqual(m, math.matrix([[5,6,7],[0,1,2],[0,3,4]]));
       m.subset(index([0,3], 0), [8,9,10]);  // unsqueezes the submatrix
-      assert.deepEqual(m, new Matrix([[8,6,7],[9,1,2],[10,3,4]]));
+      assert.deepEqual(m, math.matrix([[8,6,7],[9,1,2],[10,3,4]]));
     });
 
     it('should set the given subset with defaultValue for new elements', function() {
       // multiple values
-      var m = new Matrix();
+      var m = math.matrix();
       var defaultValue = 0;
       m.subset(index([3,5]), [3, 4], defaultValue);
-      assert.deepEqual(m, new Matrix([0, 0, 0, 3, 4]));
+      assert.deepEqual(m, math.matrix([0, 0, 0, 3, 4]));
 
       defaultValue = 1;
       m.subset(index([3,5],1), [5, 6], defaultValue);
-      assert.deepEqual(m, new Matrix([
+      assert.deepEqual(m, math.matrix([
         [0, 1],
         [0, 1],
         [0, 1],
@@ -304,7 +303,7 @@ describe('matrix', function() {
 
       defaultValue = 2;
       m.subset(index([3,5],2), [7, 8], defaultValue);
-      assert.deepEqual(m, new Matrix([
+      assert.deepEqual(m, math.matrix([
         [0, 1, 2],
         [0, 1, 2],
         [0, 1, 2],
@@ -316,58 +315,58 @@ describe('matrix', function() {
       var i = math.matrix();
       defaultValue = 0;
       i.subset(math.index(2, 1), 6, defaultValue);
-      assert.deepEqual(i, new Matrix([[0, 0], [0, 0], [0, 6]]));
+      assert.deepEqual(i, math.matrix([[0, 0], [0, 0], [0, 6]]));
     });
 
     it('should unsqueeze the replacement subset if needed', function() {
-      var m = new Matrix([[0,0],[0,0]]); // 2x2
+      var m = math.matrix([[0,0],[0,0]]); // 2x2
 
       m.subset(index(0, [0,2]), [1,1]); // 2
-      assert.deepEqual(m, new Matrix([[1,1],[0,0]]));
+      assert.deepEqual(m, math.matrix([[1,1],[0,0]]));
 
       m.subset(index([0,2], 0), [2,2]); // 2
-      assert.deepEqual(m, new Matrix([[2,1],[2,0]]));
+      assert.deepEqual(m, math.matrix([[2,1],[2,0]]));
 
-      m = new Matrix([[[0],[0],[0]]]); // 1x3x1
+      m = math.matrix([[[0],[0],[0]]]); // 1x3x1
       m.subset(index(0, [0,3], 0), [1,2,3]); // 3
-      assert.deepEqual(m, new Matrix([[[1],[2],[3]]]));
+      assert.deepEqual(m, math.matrix([[[1],[2],[3]]]));
 
-      m = new Matrix([[[0,0,0]]]); // 1x1x3
+      m = math.matrix([[[0,0,0]]]); // 1x1x3
       m.subset(index(0, 0, [0,3]), [1,2,3]); // 3
-      assert.deepEqual(m, new Matrix([[[1,2,3]]]));
+      assert.deepEqual(m, math.matrix([[[1,2,3]]]));
 
-      m = new Matrix([[[0]],[[0]],[[0]]]); // 3x1x1
+      m = math.matrix([[[0]],[[0]],[[0]]]); // 3x1x1
       m.subset(index([0,3], 0, 0), [1,2,3]); // 3
-      assert.deepEqual(m, new Matrix([[[1]],[[2]],[[3]]]));
+      assert.deepEqual(m, math.matrix([[[1]],[[2]],[[3]]]));
 
-      m = new Matrix([[[0,0,0]]]); // 1x1x3
+      m = math.matrix([[[0,0,0]]]); // 1x1x3
       m.subset(index(0, 0, [0,3]), [[1,2,3]]); // 1x3
-      assert.deepEqual(m, new Matrix([[[1,2,3]]]));
+      assert.deepEqual(m, math.matrix([[[1,2,3]]]));
 
-      m = new Matrix([[[0]],[[0]],[[0]]]); // 3x1x1
+      m = math.matrix([[[0]],[[0]],[[0]]]); // 3x1x1
       m.subset(index([0,3], 0, 0), [[1],[2],[3]]); // 3x1
-      assert.deepEqual(m, new Matrix([[[1]],[[2]],[[3]]]));
+      assert.deepEqual(m, math.matrix([[[1]],[[2]],[[3]]]));
     });
 
     it('should resize the matrix if the replacement subset is different size than selected subset', function() {
       // set 2-dimensional with resize
-      var m = new Matrix([[123]]);
+      var m = math.matrix([[123]]);
       m.subset(index([1,3], [1,3]), [[1,2],[3,4]]);
-      assert.deepEqual(m, new Matrix([[123,0,0],[0,1,2],[0,3,4]]));
+      assert.deepEqual(m, math.matrix([[123,0,0],[0,1,2],[0,3,4]]));
 
       // set resize dimensions
-      m = new Matrix([123]);
+      m = math.matrix([123]);
       assert.deepEqual(m.size(), [1]);
 
       m.subset(index([1,3], [1,3]), [[1,2],[3,4]]);
-      assert.deepEqual(m, new Matrix([[123,0,0],[0,1,2],[0,3,4]]));
+      assert.deepEqual(m, math.matrix([[123,0,0],[0,1,2],[0,3,4]]));
 
       m.subset(index([0,2], [0,2]), [[55,55],[55,55]]);
-      assert.deepEqual(m, new Matrix([[55,55,0],[55,55,2],[0,3,4]]));
+      assert.deepEqual(m, math.matrix([[55,55,0],[55,55,2],[0,3,4]]));
 
-      m = new Matrix();
+      m = math.matrix();
       m.subset(index([1,3], [1,3], [1,3]), [[[1,2],[3,4]],[[5,6],[7,8]]]);
-      var res = new Matrix([
+      var res = math.matrix([
         [
           [0, 0, 0],
           [0, 0, 0],
@@ -388,17 +387,17 @@ describe('matrix', function() {
     });
 
     it ('should throw an error in case of wrong type of index', function () {
-      assert.throws(function () {new Matrix().subset('no index', 2)}, /Invalid index/)
+      assert.throws(function () {math.matrix().subset('no index', 2);}, /Invalid index/);
     });
 
     it ('should throw an error in case of wrong size of submatrix', function () {
-      assert.throws(function () {new Matrix().subset(index(0), [2,3])}, /Scalar expected/)
+      assert.throws(function () {math.matrix().subset(index(0), [2,3]);}, /Scalar expected/);
     });
 
     it('should throw an error in case of dimension mismatch', function() {
-      var m = new Matrix([[1,2,3],[4,5,6]]);
-      assert.throws(function () {m.subset(index([0,2]), [100,100])}, /Dimension mismatch/);
-      assert.throws(function () {m.subset(index([0,2], [0,2]), [100,100])}, /Dimension mismatch/);
+      var m = math.matrix([[1,2,3],[4,5,6]]);
+      assert.throws(function () {m.subset(index([0,2]), [100,100]);}, /Dimension mismatch/);
+      assert.throws(function () {m.subset(index([0,2], [0,2]), [100,100]);}, /Dimension mismatch/);
     });
 
   });
@@ -408,7 +407,7 @@ describe('matrix', function() {
     it('should apply the given function to all elements in the matrix', function() {
       var m, m2;
 
-      m = new Matrix([
+      m = math.matrix([
         [[1,2],[3,4]],
         [[5,6],[7,8]],
         [[9,10],[11,12]],
@@ -422,24 +421,24 @@ describe('matrix', function() {
         [[26,28],[30,32]]
       ]);
 
-      m = new Matrix([1]);
+      m = math.matrix([1]);
       m2 = m.map(function (value) { return value * 2; });
       assert.deepEqual(m2.valueOf(), [2]);
 
-      m = new Matrix([1,2,3]);
+      m = math.matrix([1,2,3]);
       m2 = m.map(function (value) { return value * 2; });
       assert.deepEqual(m2.valueOf(), [2,4,6]);
     });
 
     it('should work on empty matrices', function() {
       var m, m2;
-      m = new Matrix([]);
+      m = math.matrix([]);
       m2 = m.map(function (value) { return value * 2; });
       assert.deepEqual(m2.valueOf(), []);
     });
 
     it('should invoke callback with parameters value, index, obj', function() {
-      var m = new Matrix([[1,2,3], [4,5,6]]);
+      var m = math.matrix([[1,2,3], [4,5,6]]);
 
       assert.deepEqual(m.map(function (value, index, obj) {
         return math.clone([value, index, obj === m]);
@@ -465,7 +464,7 @@ describe('matrix', function() {
     it('should run on all elements of the matrix, last dimension first', function() {
       var m, output;
 
-      m = new Matrix([
+      m = math.matrix([
         [[1,2],[3,4]],
         [[5,6],[7,8]],
         [[9,10],[11,12]],
@@ -475,26 +474,26 @@ describe('matrix', function() {
       m.forEach(function (value) { output.push(value); });
       assert.deepEqual(output, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]);
 
-      m = new Matrix([1]);
+      m = math.matrix([1]);
       output = [];
       m.forEach(function (value) { output.push(value); });
       assert.deepEqual(output, [1]);
 
-      m = new Matrix([1,2,3]);
+      m = math.matrix([1,2,3]);
       output = [];
       m.forEach(function (value) { output.push(value); });
       assert.deepEqual(output, [1,2,3]);
     });
 
     it('should work on empty matrices', function() {
-      m = new Matrix([]);
-      output = [];
+      var m = math.matrix([]);
+      var output = [];
       m.forEach(function (value) { output.push(value); });
       assert.deepEqual(output, []);
     });
 
     it('should invoke callback with parameters value, index, obj', function() {
-      var m = new Matrix([[1,2,3], [4,5,6]]);
+      var m = math.matrix([[1,2,3], [4,5,6]]);
 
       var output = [];
       m.forEach(function (value, index, obj) {
@@ -515,7 +514,7 @@ describe('matrix', function() {
   describe('clone', function() {
 
     it('should clone the matrix properly', function() {
-      var m = new Matrix([[1,2,3], [4,5,6]]);
+      var m = math.matrix([[1,2,3], [4,5,6]]);
       var m4 = m.clone();
       assert.deepEqual(m4.size(), [2,3]);
       assert.deepEqual(m4.valueOf(), [[1,2,3], [4,5,6]]);


### PR DESCRIPTION
This is the initial changes needed to port Sparse Matrix implementation
from v1